### PR TITLE
Add CommandArgs for Browser config

### DIFF
--- a/BrowserPicker/Browser.cs
+++ b/BrowserPicker/Browser.cs
@@ -45,6 +45,16 @@ namespace BrowserPicker
 			}
 		}
 
+		public string CommandArgs
+		{
+			get => commandArgs;
+			set
+			{
+				commandArgs = value;
+				OnPropertyChanged();
+			}
+		}
+
 		public string PrivacyArgs
 		{
 			get
@@ -152,16 +162,18 @@ namespace BrowserPicker
 			try
 			{
 				Config.UpdateCounter(this);
-				if(Name == "Edge")
+				var args = CommandArgs;
+				if (Name == "Edge")
 				{
-					var args = (privacy ? "-private " : string.Empty) + App.TargetURL;
-					Process.Start(Command, args);
+					var newArgs = (privacy ? "-private " : string.Empty) + App.TargetURL;
+					args = CombineArgs(args, newArgs);
 				}
 				else
 				{
-					var args = privacy ? PrivacyArgs : string.Empty;
-					Process.Start(Command, $"{args}\"{App.TargetURL}\"");
+					var newArgs = privacy ? PrivacyArgs : string.Empty;
+					args = CombineArgs(args, $"{newArgs}\"{App.TargetURL}\"");
 				}
+				Process.Start(Command, args);
 			}
 			catch
 			{
@@ -170,12 +182,22 @@ namespace BrowserPicker
 			Application.Current?.Shutdown();
 		}
 
+		private static string CombineArgs(string args1, string args2)
+		{
+			if (string.IsNullOrEmpty(args1))
+			{
+				return args2;
+			}
+			return args1 + " " + args2;
+		}
+
 		private BitmapFrame icon;
 		private bool disabled;
 		private bool removed;
 		private string name;
 		private string icon_path;
 		private string command;
+		private string commandArgs;
 		public event PropertyChangedEventHandler PropertyChanged;
 
 		[NotifyPropertyChangedInvocator]

--- a/BrowserPicker/BrowserEditor.xaml
+++ b/BrowserPicker/BrowserEditor.xaml
@@ -22,15 +22,16 @@
 
 		<Grid>
 			<Grid.ColumnDefinitions>
-				<ColumnDefinition Width="40" />
+				<ColumnDefinition Width="10" />
 				<ColumnDefinition Width="Auto" />
 				<ColumnDefinition />
 				<ColumnDefinition Width="20" />
 			</Grid.ColumnDefinitions>
 			<Grid.RowDefinitions>
 				<RowDefinition />
-				<RowDefinition />
-				<RowDefinition />
+                <RowDefinition />
+                <RowDefinition />
+                <RowDefinition />
 				<RowDefinition />
 				<RowDefinition />
 			</Grid.RowDefinitions>
@@ -42,15 +43,19 @@
 			<TextBlock Text="Name: " VerticalAlignment="Center" HorizontalAlignment="Right" Grid.Column="1" Grid.Row="1" Foreground="White" />
 			<TextBox Grid.Column="2" Grid.Row="1" Text="{Binding Name,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" Margin="2" />
 
-			<TextBlock Text="Command: " VerticalAlignment="Center" HorizontalAlignment="Right" Grid.Column="1" Grid.Row="2" Foreground="White" />
-			<TextBox Grid.Column="2" Grid.Row="2" Text="{Binding Command,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" Margin="2" />
-			<Button Content="..." Grid.Row="2" Grid.Column="3" Margin="2" FontSize="8" VerticalAlignment="Stretch" ToolTip="Browse" Click="Command_Browse" />
+            <TextBlock Text="Command: " VerticalAlignment="Center" HorizontalAlignment="Right" Grid.Column="1" Grid.Row="2" Foreground="White" />
+            <TextBox Grid.Column="2" Grid.Row="2" Text="{Binding Command,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" Margin="2" />
+            <Button Content="..." Grid.Row="2" Grid.Column="3" Margin="2" FontSize="8" VerticalAlignment="Stretch" ToolTip="Browse" Click="Command_Browse" />
 
-			<TextBlock Text="Icon: " VerticalAlignment="Center" HorizontalAlignment="Right" Grid.Column="1" Grid.Row="3" Foreground="White" />
-			<TextBox Grid.Column="2" Grid.Row="3" Text="{Binding IconPath,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" Margin="2" />
-			<Button Content="..." Grid.Row="3" Grid.Column="3" Margin="2" FontSize="8" VerticalAlignment="Stretch" ToolTip="Browse" Click="Icon_Browse" />
+            <TextBlock Text="Command Args: " VerticalAlignment="Center" HorizontalAlignment="Right" Grid.Column="1" Grid.Row="3" Foreground="White" />
+            <TextBox Grid.Column="2" Grid.Row="3" Text="{Binding CommandArgs,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" Margin="2" />
+            <Button Content="..." Grid.Row="3" Grid.Column="3" Margin="2" FontSize="8" VerticalAlignment="Stretch" ToolTip="Browse" Click="Command_Browse" />
 
-			<StackPanel Grid.Column="0" Grid.Row="4" Grid.ColumnSpan="4" HorizontalAlignment="Right" Orientation="Horizontal" Margin="5">
+            <TextBlock Text="Icon: " VerticalAlignment="Center" HorizontalAlignment="Right" Grid.Column="1" Grid.Row="4" Foreground="White" />
+			<TextBox Grid.Column="2" Grid.Row="4" Text="{Binding IconPath,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" Margin="2" />
+			<Button Content="..." Grid.Row="4" Grid.Column="3" Margin="2" FontSize="8" VerticalAlignment="Stretch" ToolTip="Browse" Click="Icon_Browse" />
+
+			<StackPanel Grid.Column="0" Grid.Row="5" Grid.ColumnSpan="4" HorizontalAlignment="Right" Orientation="Horizontal" Margin="5">
 				<Button Content="Cancel" Click="Cancel_OnClick" />
 				<Button Content="Ok" Click="Ok_OnClick" Margin="5,0,0,0" />
 			</StackPanel>

--- a/BrowserPicker/Config.cs
+++ b/BrowserPicker/Config.cs
@@ -93,6 +93,7 @@ namespace BrowserPicker
 				var key = list.CreateSubKey(browser.Name, true);
 				key.Set(nameof(browser.Name), browser.Name);
 				key.Set(nameof(browser.Command), browser.Command);
+				key.Set(nameof(browser.CommandArgs), browser.CommandArgs);
 				key.Set(nameof(browser.IconPath), browser.IconPath);
 				key.Set(nameof(browser.Usage), browser.Usage);
 			}
@@ -124,6 +125,7 @@ namespace BrowserPicker
 			{
 				Name = name,
 				Command = config.Get<string>(nameof(Browser.Command)),
+				CommandArgs = config.Get<string>(nameof(Browser.CommandArgs)),
 				IconPath = config.Get<string>(nameof(Browser.IconPath)),
 				Usage = config.Get<int>(nameof(Browser.Usage)),
 				Disabled = config.Get<bool>(nameof(Browser.Disabled))


### PR DESCRIPTION
Allow specifying arguments for the Browser in config.

This allows targeting specific Edge profiles for example:

|Command|CommandArgs|
|-|-|
|`C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe`|`--profile-directory="Profile 1"`|

