### PR TITLE
Fix designer loading when rule is set for github.com

### DIFF
--- a/BrowserPicker/ViewModel.cs
+++ b/BrowserPicker/ViewModel.cs
@@ -25,16 +25,15 @@ namespace BrowserPicker
 			Configuration = new Config();
 
 			Choices = new ObservableCollection<Browser>(Configuration.BrowserList);
+			if (Choices.Count == 0)
+				FindBrowsers();
+
+			if (Configuration.AlwaysPrompt || ConfigurationMode || forceChoice)
+				return;
 
 			if (App.TargetURL != null)
 				CheckDefaultBrowser();
 
-			if (Choices.Count == 0)
-				FindBrowsers();
-			
-			if (Configuration.AlwaysPrompt || ConfigurationMode || forceChoice)
-				return;
-			
 			var active = Choices.Where(b => b.IsRunning).ToList();
 			if (active.Count == 1)
 				active[0].Select.Execute(null);


### PR DESCRIPTION
Since configuring a default rule for `https://github.com` the designer fails to load for `MainWindow.xaml` and the browser is launched for `https://github.com`.

This PR changes the order of the checks to load the browser and skip applying the rules if we are support to show the MainWindow