### PR TITLE
Add privacy mode and running detection for Opera Stable

### DIFF
--- a/src/BrowserPicker/Configuration/Browser.cs
+++ b/src/BrowserPicker/Configuration/Browser.cs
@@ -79,6 +79,10 @@ namespace BrowserPicker.Configuration
 					case "Edge":
 						arg = EDGE_PRIVATE_ARG;
 						break;
+					case "Opera":
+					case "Opera Stable":
+						arg = OPERA_PRIVATE_ARG;
+						break;
 				}
 				if (string.IsNullOrEmpty(arg) && !string.IsNullOrEmpty(Command))
 				{
@@ -90,6 +94,8 @@ namespace BrowserPicker.Configuration
 						arg = IE_PRIVATE_ARG;
 					else if (Command.IndexOf("firefox.exe", System.StringComparison.CurrentCultureIgnoreCase) != -1)
 						arg = FIREFOX_PRIVATE_ARG;
+					else if (Command.IndexOf(@"Opera\Launcher.exe", System.StringComparison.CurrentCultureIgnoreCase) != -1)
+						arg = OPERA_PRIVATE_ARG;
 				}
 				return arg;
 			}
@@ -126,6 +132,7 @@ namespace BrowserPicker.Configuration
 					var cmd = Command;
 					if (cmd[0] == '"')
 						cmd = cmd.Split('"')[1];
+					cmd = cmd.Replace(@"Opera\Launcher.exe", @"Opera\Opera.exe");
 					return Process.GetProcessesByName(Path.GetFileNameWithoutExtension(cmd)).Any(p => p.SessionId == session);
 				}
 				catch
@@ -261,6 +268,7 @@ namespace BrowserPicker.Configuration
 		private const string IE_PRIVATE_ARG = "-private ";
 		private const string FIREFOX_PRIVATE_ARG = "-private-window ";
 		private const string CHROME_PRIVATE_ARG = "--incognito ";
+		private const string OPERA_PRIVATE_ARG = "--incognito ";
 		private const string EDGE_PRIVATE_ARG = "-inprivate ";
 	}
 }


### PR DESCRIPTION
Addresses #59 by checking for "Opera" (or "Opera Stable" as the entry is called by default) as the name, "Opera\Launcher.exe" to identify the command, and "Opera\Opera.exe" to identify the process (including the "Opera" pathname to distinguish it from other executables called Launcher.exe).
I've also worked on a solution for other versions of Opera (GX, beta, and developer), see branch "opera-compatibility-wip", but it's not ideal because it can't distinguish between the processes, since the code only checks the process name (and they are all called opera.exe) rather than the full path to the executable. So let me know what you think about it.