### PR TITLE
Remove incorrect xaml configuration, fixes #116

### DIFF
--- a/src/BrowserPicker.App/View/Configuration.xaml
+++ b/src/BrowserPicker.App/View/Configuration.xaml
@@ -220,7 +220,6 @@
 											ItemsSource="{Binding Source={StaticResource MatchTypes}}"
 											IsSynchronizedWithCurrentItem="False"
 											SelectedValue="{Binding Type}"
-											SelectedValuePath="Model.Name"
 											VerticalContentAlignment="Center" />
 									</DataTemplate>
 								</DataGridTemplateColumn.CellTemplate>


### PR DESCRIPTION
An incorrect configuration of the UI made the dropdown for type of match not work like it should in the defaults configuration UI