### PR TITLE
Fix disabled browser persistence on launch

### DIFF
--- a/src/BrowserPicker.Windows/AppSettings.cs
+++ b/src/BrowserPicker.Windows/AppSettings.cs
@@ -445,7 +445,13 @@ public sealed class AppSettings : ModelBase, IBrowserPickerConfiguration
 
 	private void AddOrUpdateBrowserModel(BrowserModel model)
 	{
-		var update = BrowserList.FirstOrDefault(m => string.Equals(m.Id, model.Name, StringComparison.CurrentCultureIgnoreCase));
+		// Match both stable ids and display names so startup discovery merges with migrated
+		// registry-backed entries whose ids may be legacy values like "ChromeHTML".
+		var update = BrowserList.FirstOrDefault(m =>
+			string.Equals(m.Id, model.Id, StringComparison.OrdinalIgnoreCase)
+			|| string.Equals(m.Id, model.Name, StringComparison.OrdinalIgnoreCase)
+			|| string.Equals(m.Name, model.Id, StringComparison.OrdinalIgnoreCase)
+			|| string.Equals(m.Name, model.Name, StringComparison.OrdinalIgnoreCase));
 		if (update != null)
 		{
 			if (update.ManualOverride)

--- a/src/BrowserPicker.Windows/JsonAppSettings.cs
+++ b/src/BrowserPicker.Windows/JsonAppSettings.cs
@@ -203,7 +203,13 @@ public sealed class JsonAppSettings : ModelBase, IBrowserPickerConfiguration
 
 	private void AddOrUpdateBrowserModel(BrowserModel model)
 	{
-		var update = BrowserList.FirstOrDefault(m => string.Equals(m.Id, model.Name, StringComparison.OrdinalIgnoreCase));
+		// Match both stable ids and display names so startup discovery merges with migrated
+		// registry-backed entries whose ids may be legacy values like "ChromeHTML".
+		var update = BrowserList.FirstOrDefault(m =>
+			string.Equals(m.Id, model.Id, StringComparison.OrdinalIgnoreCase)
+			|| string.Equals(m.Id, model.Name, StringComparison.OrdinalIgnoreCase)
+			|| string.Equals(m.Name, model.Id, StringComparison.OrdinalIgnoreCase)
+			|| string.Equals(m.Name, model.Name, StringComparison.OrdinalIgnoreCase));
 		if (update != null)
 		{
 			if (update.ManualOverride) return;

--- a/src/BrowserPicker/BrowserModel.cs
+++ b/src/BrowserPicker/BrowserModel.cs
@@ -141,7 +141,12 @@ public sealed class BrowserModel : ModelBase
         set
         {
             removed = value;
-            Disabled = value;
+            // Removing a browser should always disable it, but loading or undoing a non-removed
+            // state must not implicitly re-enable a browser that the user disabled separately.
+            if (value)
+            {
+                Disabled = true;
+            }
             OnPropertyChanged();
         }
     }


### PR DESCRIPTION
## Summary
- preserve the user's disabled browser state when settings are reloaded on startup
- prevent startup discovery from re-adding an existing browser entry when ids and display names differ
- Fixes #213

## Test plan
- [x] Build `BrowserPicker.sln` with `-p:Version=1.0.0`
- [x] Disable Internet Explorer in config, close BrowserPicker, and relaunch with a URL
- [x] Confirm the browser remains disabled after launch