### PR TITLE
Prevent removing well-known browsers and polish the browser editor

### DIFF
--- a/src/BrowserPicker.App/View/BrowserEditor.xaml
+++ b/src/BrowserPicker.App/View/BrowserEditor.xaml
@@ -10,7 +10,7 @@
 	Background="Transparent"
 	mc:Ignorable="d"
 	d:DataContext="{d:DesignInstance viewModel:BrowserViewModel,d:IsDesignTimeCreatable=true}"
-	Title="Browser Picker" WindowStartupLocation="CenterScreen" SizeToContent="WidthAndHeight" ResizeMode="NoResize" 
+	Title="Browser Picker" WindowStartupLocation="CenterScreen" SizeToContent="Height" Width="580" MinWidth="580" ResizeMode="NoResize" 
 	AllowsTransparency="True" WindowStyle="None"
 	ShowInTaskbar="False" Topmost="True">
 	
@@ -30,54 +30,118 @@
 				<Setter Property="VerticalContentAlignment" Value="Center" />
 				<Setter Property="MinHeight" Value="28" />
 				<Setter Property="Padding" Value="6,4" />
+				<Setter Property="TextWrapping" Value="NoWrap" />
+			</Style>
+			<Style x:Key="EllipsisTextBox" TargetType="TextBox" BasedOn="{StaticResource {x:Type TextBox}}">
+				<Style.Triggers>
+					<Trigger Property="IsKeyboardFocusWithin" Value="False">
+						<Setter Property="Foreground" Value="Transparent" />
+					</Trigger>
+				</Style.Triggers>
+			</Style>
+			<Style x:Key="EllipsisOverlayText" TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
+				<Setter Property="Margin" Value="8,0" />
+				<Setter Property="VerticalAlignment" Value="Center" />
+				<Setter Property="TextWrapping" Value="NoWrap" />
+				<Setter Property="TextTrimming" Value="CharacterEllipsis" />
+				<Setter Property="IsHitTestVisible" Value="False" />
 			</Style>
 		</ResourceDictionary>
 	</Window.Resources>
 	<Border CornerRadius="5" BorderBrush="{DynamicResource {x:Static app:App.ContentForegroundBrushKey}}" BorderThickness="2" Background="{DynamicResource {x:Static app:App.ContentBackgroundBrushKey}}" Padding="10" MinWidth="400" MouseLeftButtonDown="DragWindow">
 		<Grid TextElement.Foreground="{DynamicResource {x:Static app:App.ContentForegroundBrushKey}}">
 			<Grid.ColumnDefinitions>
-				<ColumnDefinition Width="10" />
+				<ColumnDefinition Width="56" />
 				<ColumnDefinition Width="Auto" />
 				<ColumnDefinition />
-				<ColumnDefinition Width="20" />
+				<ColumnDefinition Width="44" />
 			</Grid.ColumnDefinitions>
 			<Grid.RowDefinitions>
-				<RowDefinition />
-				<RowDefinition />
-				<RowDefinition />
-				<RowDefinition />
-				<RowDefinition />
-				<RowDefinition />
-				<RowDefinition />
-				<RowDefinition />
-				<RowDefinition />
-				<RowDefinition />
+				<RowDefinition Height="Auto" />
+				<RowDefinition Height="Auto" />
+				<RowDefinition Height="Auto" />
+				<RowDefinition Height="Auto" />
+				<RowDefinition Height="Auto" />
+				<RowDefinition Height="Auto" />
+				<RowDefinition Height="Auto" />
+				<RowDefinition Height="Auto" />
+				<RowDefinition Height="Auto" />
+				<RowDefinition Height="Auto" />
 			</Grid.RowDefinitions>
 
-			<TextBlock Grid.Row="0" Grid.ColumnSpan="4" Text="Add a browser"  HorizontalAlignment="Center" Margin="5" />
+			<TextBlock Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="3" Text="Add a browser" HorizontalAlignment="Center" Margin="5" />
 
-			<Image Grid.Row="1" Grid.Column="0" Grid.RowSpan="3" VerticalAlignment="Center" HorizontalAlignment="Center" MaxWidth="32" MaxHeight="32" Source="{Binding Model.IconPath, Converter={StaticResource IconConverter}}" />
+			<Image Grid.Row="0" Grid.Column="0" Grid.RowSpan="3" Margin="4,4,8,0" Width="40" Height="40" VerticalAlignment="Top" HorizontalAlignment="Left" Source="{Binding Model.IconPath, Converter={StaticResource IconConverter}}" />
 
 			<TextBlock Text="Name: " VerticalAlignment="Center" HorizontalAlignment="Right" Grid.Column="1" Grid.Row="1"  />
 			<TextBox Grid.Column="2" Grid.Row="1" Text="{Binding Model.Name,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" Margin="2" />
 
 			<TextBlock Text="Command: " VerticalAlignment="Center" HorizontalAlignment="Right" Grid.Column="1" Grid.Row="2"  />
-			<TextBox Grid.Column="2" Grid.Row="2" Text="{Binding Model.Command,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" Margin="2" />
-			<Button Content="..." Grid.Row="2" Grid.Column="3" Margin="2" FontSize="8" VerticalAlignment="Stretch" ToolTip="Browse" Click="Command_Browse" />
+			<Grid Grid.Column="2" Grid.Row="2" Margin="2">
+				<TextBox x:Name="CommandTextBox" Style="{StaticResource EllipsisTextBox}" Text="{Binding Model.Command,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" ToolTip="{Binding Model.Command}" />
+				<TextBlock Text="{Binding Text, ElementName=CommandTextBox}">
+					<TextBlock.Style>
+						<Style TargetType="TextBlock" BasedOn="{StaticResource EllipsisOverlayText}">
+							<Style.Triggers>
+								<DataTrigger Binding="{Binding IsKeyboardFocusWithin, ElementName=CommandTextBox}" Value="True">
+									<Setter Property="Visibility" Value="Collapsed" />
+								</DataTrigger>
+							</Style.Triggers>
+						</Style>
+					</TextBlock.Style>
+				</TextBlock>
+			</Grid>
+			<Button Content="..." Grid.Row="2" Grid.Column="3" Margin="2" Width="36" Height="28" HorizontalAlignment="Center" ToolTip="Browse" Click="Command_Browse" />
 
 			<TextBlock Text="Command Args: " VerticalAlignment="Center" HorizontalAlignment="Right" Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="3"  />
-			<TextBox Grid.Column="2" Grid.Row="3" Text="{Binding Model.CommandArgs,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" Margin="2" />
+			<Grid Grid.Column="2" Grid.Row="3" Margin="2">
+				<TextBox x:Name="CommandArgsTextBox" Style="{StaticResource EllipsisTextBox}" Text="{Binding Model.CommandArgs,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" ToolTip="{Binding Model.CommandArgs}" />
+				<TextBlock Text="{Binding Text, ElementName=CommandArgsTextBox}">
+					<TextBlock.Style>
+						<Style TargetType="TextBlock" BasedOn="{StaticResource EllipsisOverlayText}">
+							<Style.Triggers>
+								<DataTrigger Binding="{Binding IsKeyboardFocusWithin, ElementName=CommandArgsTextBox}" Value="True">
+									<Setter Property="Visibility" Value="Collapsed" />
+								</DataTrigger>
+							</Style.Triggers>
+						</Style>
+					</TextBlock.Style>
+				</TextBlock>
+			</Grid>
 
 			<TextBlock Text="Icon: " VerticalAlignment="Center" HorizontalAlignment="Right" Grid.Column="1" Grid.Row="4"  />
-			<TextBox Grid.Column="2" Grid.Row="4" Text="{Binding Model.IconPath,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" Margin="2" />
-			<Button Content="..." Grid.Row="4" Grid.Column="3" Margin="2" FontSize="8" VerticalAlignment="Stretch" ToolTip="Browse" Click="Icon_Browse" />
+			<Grid Grid.Column="2" Grid.Row="4" Margin="2">
+				<TextBox x:Name="IconPathTextBox" Style="{StaticResource EllipsisTextBox}" Text="{Binding Model.IconPath,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" ToolTip="{Binding Model.IconPath}" />
+				<TextBlock Text="{Binding Text, ElementName=IconPathTextBox}">
+					<TextBlock.Style>
+						<Style TargetType="TextBlock" BasedOn="{StaticResource EllipsisOverlayText}">
+							<Style.Triggers>
+								<DataTrigger Binding="{Binding IsKeyboardFocusWithin, ElementName=IconPathTextBox}" Value="True">
+									<Setter Property="Visibility" Value="Collapsed" />
+								</DataTrigger>
+							</Style.Triggers>
+						</Style>
+					</TextBlock.Style>
+				</TextBlock>
+			</Grid>
+			<Button Content="..." Grid.Row="4" Grid.Column="3" Margin="2" Width="36" Height="28" HorizontalAlignment="Center" ToolTip="Browse" Click="Icon_Browse" />
 
 			<CheckBox Grid.Row="5" Grid.Column="2" Content="Expand file:// urls" IsChecked="{Binding Model.ExpandFileUrls}"  Margin="2,4" />
 
 			<TextBlock Text="Privacy Args: " VerticalAlignment="Center" HorizontalAlignment="Right" Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="6"  />
 			<TextBox Grid.Column="2" Grid.Row="6" Text="{Binding Model.PrivacyArgs,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" Margin="2" />
 
-			<CheckBox Grid.Row="7" Grid.Column="2" Content="Disable automatic updates" IsChecked="{Binding Model.ManualOverride}"  Margin="2,4" />
+			<CheckBox Grid.Row="7" Grid.Column="2" Content="Disable automatic updates" IsChecked="{Binding Model.ManualOverride}" Margin="2,4">
+				<CheckBox.Style>
+					<Style TargetType="CheckBox" BasedOn="{StaticResource {x:Type CheckBox}}">
+						<Style.Triggers>
+							<DataTrigger Binding="{Binding IsWellKnown}" Value="False">
+								<Setter Property="Visibility" Value="Collapsed" />
+							</DataTrigger>
+						</Style.Triggers>
+					</Style>
+				</CheckBox.Style>
+			</CheckBox>
 
 			<TextBlock Text="Hotkey:" VerticalAlignment="Center" HorizontalAlignment="Right" Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="8"  />
 			<Grid Grid.Column="2" Grid.Row="8">

--- a/src/BrowserPicker.App/View/Configuration.xaml
+++ b/src/BrowserPicker.App/View/Configuration.xaml
@@ -211,6 +211,7 @@
 														<Style>
 															<Setter Property="TextBlock.Foreground" Value="Green" />
 															<Setter Property="TextBlock.Text" Value="Enabled" />
+															<Setter Property="FrameworkElement.ToolTip" Value="Toggle whether this browser appears in the picker" />
 															<Style.Triggers>
 																<DataTrigger Binding="{Binding Model.Disabled}" Value="True">
 																	<Setter Property="TextBlock.Foreground" Value="OrangeRed" />
@@ -233,8 +234,17 @@
 										</Hyperlink>
 									</TextBlock>
 										<TextBlock Grid.Column="6" Margin="10" FontSize="16">
+											<TextBlock.Style>
+												<Style TargetType="TextBlock">
+													<Style.Triggers>
+														<DataTrigger Binding="{Binding CanRemove}" Value="False">
+															<Setter Property="Visibility" Value="Hidden" />
+														</DataTrigger>
+													</Style.Triggers>
+												</Style>
+											</TextBlock.Style>
 										<Hyperlink Command="{Binding Remove}">
-											<TextBlock Text="X" Foreground="Red" ToolTip="Remove browser from list" />
+											<TextBlock Text="X" Foreground="Red" ToolTip="Remove custom browser from list" />
 										</Hyperlink>
 									</TextBlock>
 									</Grid>

--- a/src/BrowserPicker.App/ViewModel/BrowserViewModel.cs
+++ b/src/BrowserPicker.App/ViewModel/BrowserViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -72,6 +72,13 @@ public sealed class BrowserViewModel : ViewModelBase<BrowserModel>
 	{
 		switch (e.PropertyName)
 		{
+			case nameof(BrowserModel.Id):
+			case nameof(BrowserModel.Name):
+				OnPropertyChanged(nameof(IsWellKnown));
+				OnPropertyChanged(nameof(CanRemove));
+				Remove.RaiseCanExecuteChanged();
+				break;
+
 			case nameof(BrowserModel.PrivacyArgs):
 				SelectPrivacy.RaiseCanExecuteChanged();
 				break;
@@ -87,6 +94,16 @@ public sealed class BrowserViewModel : ViewModelBase<BrowserModel>
 	/// Gets a value indicating whether the browser list is ordered manually.
 	/// </summary>
 	public bool IsManuallyOrdered => !parent_view_model.Configuration.Settings.UseAutomaticOrdering;
+
+	/// <summary>
+	/// Gets a value indicating whether this browser came from the built-in well-known browser list.
+	/// </summary>
+	public bool IsWellKnown => WellKnownBrowsers.Lookup(string.IsNullOrWhiteSpace(Model.Id) ? Model.Name : Model.Id, null) != null;
+
+	/// <summary>
+	/// Gets a value indicating whether this browser can be permanently removed from the configuration.
+	/// </summary>
+	public bool CanRemove => !IsWellKnown;
 
 	/// <summary>
 	/// Gets the command to select the browser.
@@ -106,7 +123,7 @@ public sealed class BrowserViewModel : ViewModelBase<BrowserModel>
 	/// <summary>
 	/// Gets the command to remove the browser from the list.
 	/// </summary>
-	public DelegateCommand Remove => remove ??= new DelegateCommand(() => Model.Removed = true);
+	public DelegateCommand Remove => remove ??= new DelegateCommand(() => Model.Removed = true, () => CanRemove);
 	
 	/// <summary>
 	/// Gets the command to open the browser editor.
@@ -219,6 +236,7 @@ public sealed class BrowserViewModel : ViewModelBase<BrowserModel>
 	{
 		var temp = new BrowserModel
 		{
+			Id = model.Id,
 			Command = Model.Command,
 			CommandArgs = model.CommandArgs,
 			Executable = model.Executable,


### PR DESCRIPTION
## Summary
- prevent built-in browsers from looking removable by hiding the red `X` and guarding removal for well-known entries while leaving custom browsers removable
- preserve well-known browser identity in the editor so renamed built-in browsers still show update controls correctly
- polish the browser editor layout with stable sizing, ellipsis handling for long paths, larger icon placement, and uncropped browse buttons

Fixes #223

## Test plan
- [x] `dotnet build src/BrowserPicker.App/BrowserPicker.App.csproj -p:Version=1.0.0`
- [x] Manually checked that custom browsers still show the remove action while well-known browsers do not
- [x] Manually checked the browser editor sizing, browse buttons, path truncation, and renamed well-known browser behavior
