### PR TITLE
Fix process exit after automatic browser launch

### DIFF
--- a/src/BrowserPicker.App/App.xaml.cs
+++ b/src/BrowserPicker.App/App.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -313,7 +313,10 @@ public partial class App
 	/// </summary>
 	private void ShowMainWindow()
 	{
-		ViewModel?.Initialize();
+		if (ViewModel?.Initialize() == false)
+		{
+			return;
+		}
 		MainWindow = new MainWindow
 		{
 			DataContext = ViewModel

--- a/src/BrowserPicker.App/ViewModel/ApplicationViewModel.cs
+++ b/src/BrowserPicker.App/ViewModel/ApplicationViewModel.cs
@@ -88,17 +88,18 @@ public sealed class ApplicationViewModel : ModelBase
 	public UrlHandler Url { get; }
 
 	/// <summary>
-	/// Initializes the application state. Handles first-time setup, configuration mode, 
+	/// Initializes the application state. Handles first-time setup, configuration mode,
 	/// and optional automatic browser launch based on URL and settings.
 	/// </summary>
-	public void Initialize()
+	/// <returns><see langword="true"/> when the main window should be shown; otherwise <see langword="false"/>.</returns>
+	public bool Initialize()
 	{
 		if (Configuration.Settings.FirstTime)
 		{
 			Configuration.Welcome = true;
 			ConfigurationMode = true;
 			Configuration.Settings.FirstTime = false;
-			return;
+			return true;
 		}
 
 		if (
@@ -108,7 +109,7 @@ public sealed class ApplicationViewModel : ModelBase
 			|| ConfigurationMode
 			|| force_choice)
 		{
-			return;
+			return true;
 		}
 
 		BrowserViewModel? start = GetBrowserToLaunch(Url.UnderlyingTargetURL ?? Url.TargetURL);
@@ -118,10 +119,16 @@ public sealed class ApplicationViewModel : ModelBase
 		if (Debugger.IsAttached && start != null)
 		{
 			Debug.WriteLine($"Skipping launch of browser {start.Model.Name} due to debugger being attached");
-			return;
+			return true;
 		}
 #endif
-		start?.Select.Execute(null);
+		if (start == null)
+		{
+			return true;
+		}
+
+		start.Select.Execute(null);
+		return false;
 	}
 
 	/// <summary>

--- a/src/BrowserPicker.App/ViewModel/BrowserViewModel.cs
+++ b/src/BrowserPicker.App/ViewModel/BrowserViewModel.cs
@@ -1,3 +1,4 @@
+using System;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
@@ -380,7 +381,14 @@ public sealed class BrowserViewModel : ViewModelBase<BrowserModel>
 		{
 			// ignored
 		}
-		Application.Current?.Shutdown();
+		if (parent_view_model.OnShutdown != null)
+		{
+			parent_view_model.OnShutdown(this, EventArgs.Empty);
+		}
+		else
+		{
+			Application.Current?.Shutdown();
+		}
 		return;
 		
 		string CombineArgs(string? args1, string args2)


### PR DESCRIPTION
## Summary
- Avoid showing the picker window after an automatic browser selection already launched the target browser.
- Route automatic-launch shutdown through the normal app shutdown path so background tasks are cancelled consistently.
- Fixes #227.

## Test plan
- [x] `dotnet build "src/BrowserPicker.App/BrowserPicker.App.csproj" -p:Version=1.0.0`
- [ ] Manually verify the Outlook/Slack link path no longer leaves BrowserPicker running after auto-launch.
