### PR TITLE
add close button to picker window

### DIFF
--- a/src/BrowserPicker.App/View/BrowserList.xaml
+++ b/src/BrowserPicker.App/View/BrowserList.xaml
@@ -20,7 +20,7 @@
 			<RowDefinition Height="*" />
 			<RowDefinition Height="Auto" />
 		</Grid.RowDefinitions>
-		<StackPanel Orientation="Vertical">
+		<StackPanel Orientation="Vertical" Margin="0,0,50,0">
 			<StackPanel Orientation="Horizontal">
 				<Image Source="{DynamicResource DefaultIcon}" Height="16" Margin="5" />
 				<TextBlock Margin="0,5">
@@ -95,7 +95,7 @@
 				</TextBlock>
 			</Border>
 		</StackPanel>
-		<Grid Grid.Row="0">
+		<Grid Grid.Row="0" Margin="0,0,50,0">
 			<Grid.Style>
 				<Style TargetType="{x:Type Grid}">
 					<Style.Triggers>

--- a/src/BrowserPicker.App/View/MainWindow.xaml
+++ b/src/BrowserPicker.App/View/MainWindow.xaml
@@ -46,45 +46,66 @@
 					</Style.Triggers>
 				</Style>
 			</Border.Style>
-			<Grid Margin="10" x:Name="RootContent" TextElement.FontSize="{Binding Configuration.Settings.FontSize, FallbackValue=14}"
+			<Grid x:Name="RootContent" TextElement.FontSize="{Binding Configuration.Settings.FontSize, FallbackValue=14}"
 				TextElement.Foreground="{DynamicResource {x:Static app:App.ContentForegroundBrushKey}}">
-				<Grid.RowDefinitions>
-					<RowDefinition Height="*" />
-				</Grid.RowDefinitions>
-				<Border Grid.Row="0" Grid.Column="0">
-					<Border.Style>
-						<Style>
-							<Setter Property="UIElement.Visibility" Value="Visible" />
-							<Style.Triggers>
-								<DataTrigger Binding="{Binding ConfigurationMode}" Value="True">
-									<Setter Property="UIElement.Visibility" Value="Collapsed" />
-								</DataTrigger>
-							</Style.Triggers>
-						</Style>
-					</Border.Style>
-					<view:BrowserList />
-				</Border>
-				<Border Grid.Row="0" Grid.Column="0">
-					<Border.Style>
-						<Style>
-							<Setter Property="UIElement.Visibility" Value="Collapsed" />
-							<Style.Triggers>
-								<DataTrigger Binding="{Binding ConfigurationMode}" Value="True">
-									<Setter Property="UIElement.Visibility" Value="Visible" />
-								</DataTrigger>
-							</Style.Triggers>
-						</Style>
-					</Border.Style>
-					<view:Configuration DataContext="{Binding Configuration}" />
-				</Border>
-				<Canvas x:Name="ResizeGrip" Grid.Row="0" Grid.Column="0" Width="14" Height="14" Cursor="SizeNWSE"
-					HorizontalAlignment="Right" VerticalAlignment="Bottom"
+				<Grid Margin="10">
+					<Grid.RowDefinitions>
+						<RowDefinition Height="*" />
+					</Grid.RowDefinitions>
+					<Border Grid.Row="0" Grid.Column="0">
+						<Border.Style>
+							<Style>
+								<Setter Property="UIElement.Visibility" Value="Visible" />
+								<Style.Triggers>
+									<DataTrigger Binding="{Binding ConfigurationMode}" Value="True">
+										<Setter Property="UIElement.Visibility" Value="Collapsed" />
+									</DataTrigger>
+								</Style.Triggers>
+							</Style>
+						</Border.Style>
+						<view:BrowserList />
+					</Border>
+					<Border Grid.Row="0" Grid.Column="0">
+						<Border.Style>
+							<Style>
+								<Setter Property="UIElement.Visibility" Value="Collapsed" />
+								<Style.Triggers>
+									<DataTrigger Binding="{Binding ConfigurationMode}" Value="True">
+										<Setter Property="UIElement.Visibility" Value="Visible" />
+									</DataTrigger>
+								</Style.Triggers>
+							</Style>
+						</Border.Style>
+						<view:Configuration DataContext="{Binding Configuration}" />
+					</Border>
+					<Canvas x:Name="ResizeGrip" Grid.Row="0" Grid.Column="0" Width="14" Height="14" Cursor="SizeNWSE"
+						HorizontalAlignment="Right" VerticalAlignment="Bottom"
+						Background="Transparent"
+						PreviewMouseLeftButtonDown="ResizeGrip_PreviewMouseLeftButtonDown">
+						<!-- Two diagonal lines for grip (⌟), theme-aware -->
+						<Line X1="4" Y1="14" X2="14" Y2="4" Stroke="{DynamicResource {x:Static app:App.ContentForegroundBrushKey}}" StrokeThickness="1.5" Opacity="0.6" />
+						<Line X1="9" Y1="14" X2="14" Y2="9" Stroke="{DynamicResource {x:Static app:App.ContentForegroundBrushKey}}" StrokeThickness="1.5" Opacity="0.6" />
+					</Canvas>
+				</Grid>
+				<Button
+					Command="{Binding Exit}"
+					Cursor="Hand"
+					Width="50"
+					Height="40"
+					Padding="0,2,0,0"
+					FontSize="10"
+					FontFamily="Segoe MDL2 Assets"
+					FontWeight="Normal"
 					Background="Transparent"
-					PreviewMouseLeftButtonDown="ResizeGrip_PreviewMouseLeftButtonDown">
-					<!-- Two diagonal lines for grip (⌟), theme-aware -->
-					<Line X1="4" Y1="14" X2="14" Y2="4" Stroke="{DynamicResource {x:Static app:App.ContentForegroundBrushKey}}" StrokeThickness="1.5" Opacity="0.6" />
-					<Line X1="9" Y1="14" X2="14" Y2="9" Stroke="{DynamicResource {x:Static app:App.ContentForegroundBrushKey}}" StrokeThickness="1.5" Opacity="0.6" />
-				</Canvas>
+					Foreground="Silver"
+					BorderThickness="0"
+					BorderBrush="Transparent"
+					HorizontalAlignment="Right"
+					VerticalAlignment="Top"
+					HorizontalContentAlignment="Center"
+					VerticalContentAlignment="Center"
+					ToolTip="Close Browser Picker"
+					Content="&#xE8BB;" />
 			</Grid>
 		</Border>
 	</Border>


### PR DESCRIPTION
## Summary
- add a close button in the top-right corner of the main window
- prevent close button from overlapping other UI in the window header

## Test plan
- [x] Build `src/BrowserPicker.App/BrowserPicker.App.csproj` with `-p:Version=1.0.0`
- [x] Verify the picker can be closed with the mouse when pinned
- [x] Verify the top URL/header content does not overlap the close button

Fixes #197