### PR TITLE
Fix url editor dialog and designer initialization

### DIFF
--- a/src/BrowserPicker.App/App.xaml.cs
+++ b/src/BrowserPicker.App/App.xaml.cs
@@ -176,7 +176,8 @@ public partial class App
 	/// <summary>Returns current content theme brushes (for code-behind so Configuration always gets correct colors at runtime).</summary>
 	internal static void GetContentThemeBrushes(out SolidColorBrush background, out SolidColorBrush foreground)
 	{
-		var useLight = Settings.ThemeMode switch
+		var mode = ReferenceEquals(Settings, null) ? BrowserPicker.ThemeMode.System : Settings.ThemeMode;
+		var useLight = mode switch
 		{
 			BrowserPicker.ThemeMode.Light => true,
 			BrowserPicker.ThemeMode.Dark => false,

--- a/src/BrowserPicker.App/View/BrowserList.xaml
+++ b/src/BrowserPicker.App/View/BrowserList.xaml
@@ -63,16 +63,6 @@
 						📋
 					</Hyperlink>
 					<Hyperlink TextDecorations="None" Command="{Binding Edit}" Foreground="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}" ToolTip="Edit the URL before opening it">
-						<Hyperlink.Style>
-							<Style>
-								<Setter Property="UIElement.Visibility" Value="Collapsed" />
-								<Style.Triggers>
-									<DataTrigger Binding="{Binding EditURL}" Value="{x:Null}">
-										<Setter Property="UIElement.Visibility" Value="Visible" />
-									</DataTrigger>
-								</Style.Triggers>
-							</Style>
-						</Hyperlink.Style>
 						✏
 					</Hyperlink>
 				</TextBlock>
@@ -95,32 +85,6 @@
 				</TextBlock>
 			</Border>
 		</StackPanel>
-		<Grid Grid.Row="0" Margin="0,0,50,0">
-			<Grid.Style>
-				<Style TargetType="{x:Type Grid}">
-					<Style.Triggers>
-						<DataTrigger Binding="{Binding EditURL}" Value="{x:Null}">
-							<Setter Property="UIElement.Visibility" Value="Collapsed" />
-						</DataTrigger>
-					</Style.Triggers>
-				</Style>
-			</Grid.Style>
-			<Grid.ColumnDefinitions>
-				<ColumnDefinition Width="*" />
-				<ColumnDefinition Width="Auto" />
-			</Grid.ColumnDefinitions>
-			<TextBox
-				Grid.Row="0" MaxWidth="500" MaxHeight="70"
-				Text="{Binding EditURL, UpdateSourceTrigger=PropertyChanged}"
-				KeyUp="Editor_KeyUp"
-				HorizontalAlignment="Stretch" TextWrapping="WrapWithOverflow"
-				Background="{DynamicResource {x:Static app:App.ContentBackgroundBrushKey}}"
-				Foreground="{DynamicResource {x:Static app:App.ContentForegroundBrushKey}}"
-				BorderBrush="{DynamicResource {x:Static app:App.ContentForegroundBrushKey}}" />
-			<TextBlock Grid.Column="1" Margin="5,0,0,0">
-				<Hyperlink Command="{Binding EndEdit}" Foreground="{DynamicResource {x:Static app:App.ContentForegroundBrushKey}}" TextDecorations="None">✔️</Hyperlink>
-			</TextBlock>
-		</Grid>
 		<ScrollViewer x:Name="BrowserListScroll" Grid.Row="1" HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto" SizeChanged="BrowserListScroll_SizeChanged">
 			<ItemsControl ItemsSource="{Binding Choices}">
 				<ItemsControl.ItemsPanel>

--- a/src/BrowserPicker.App/View/BrowserList.xaml.cs
+++ b/src/BrowserPicker.App/View/BrowserList.xaml.cs
@@ -1,6 +1,5 @@
 using System.Windows;
 using System.Windows.Threading;
-using BrowserPicker.ViewModel;
 
 namespace BrowserPicker.View;
 
@@ -29,20 +28,6 @@ public partial class BrowserList
 
 	private void ButtonBase_OnClick(object sender, RoutedEventArgs e)
 	{
-		e.Handled = true;
-	}
-
-	private void Editor_KeyUp(object sender, System.Windows.Input.KeyEventArgs e)
-	{
-		if (e.Key is not (System.Windows.Input.Key.Enter))
-		{
-			return;
-		}
-
-		if (DataContext is ApplicationViewModel app)
-		{
-			app.EndEdit.Execute(null);
-		}
 		e.Handled = true;
 	}
 }

--- a/src/BrowserPicker.App/View/LoadingWindow.xaml.cs
+++ b/src/BrowserPicker.App/View/LoadingWindow.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows;
+using System.Windows;
+using System.ComponentModel;
 
 namespace BrowserPicker.View;
 
@@ -10,6 +11,8 @@ public partial class LoadingWindow
 	public LoadingWindow()
 	{
 		InitializeComponent();
+		if (DesignerProperties.GetIsInDesignMode(this) || Application.Current is not App { ViewModel: not null })
+			return;
 		DataContext = ((App)Application.Current).ViewModel;
 	}
 

--- a/src/BrowserPicker.App/View/MainWindow.xaml.cs
+++ b/src/BrowserPicker.App/View/MainWindow.xaml.cs
@@ -25,6 +25,8 @@ public partial class MainWindow
 	public MainWindow()
 	{
 		InitializeComponent();
+		if (DesignerProperties.GetIsInDesignMode(this) || Application.Current is not App { ViewModel: not null })
+			return;
 		DataContext = ((App)Application.Current).ViewModel;
 		if (App.Settings is INotifyPropertyChanged inpc)
 			inpc.PropertyChanged += Settings_PropertyChanged;

--- a/src/BrowserPicker.App/View/UrlEditor.xaml
+++ b/src/BrowserPicker.App/View/UrlEditor.xaml
@@ -1,0 +1,48 @@
+<Window
+	x:Class="BrowserPicker.View.UrlEditor"
+	x:Name="Self"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:app="clr-namespace:BrowserPicker"
+	mc:Ignorable="d"
+	Title="Edit URL"
+	Width="720"
+	Height="240"
+	MinWidth="520"
+	MinHeight="220"
+	WindowStartupLocation="CenterOwner"
+	ShowInTaskbar="False"
+	PreviewKeyUp="Window_OnPreviewKeyUp"
+	Loaded="Window_OnLoaded"
+	Background="{DynamicResource {x:Static app:App.ContentBackgroundBrushKey}}"
+	Foreground="{DynamicResource {x:Static app:App.ContentForegroundBrushKey}}">
+	<Grid Margin="12">
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="*" />
+			<RowDefinition Height="Auto" />
+		</Grid.RowDefinitions>
+		<TextBlock Text="Edit target URL" FontSize="16" Margin="0,0,0,8" />
+		<TextBox
+			x:Name="EditorTextBox"
+			Grid.Row="1"
+			Style="{StaticResource DefaultTextBoxBaseStyle}"
+			Text="{Binding EditedUrl, ElementName=Self, UpdateSourceTrigger=PropertyChanged}"
+			HorizontalAlignment="Stretch"
+			VerticalAlignment="Stretch"
+			Padding="8,6"
+			AcceptsReturn="True"
+			MinLines="5"
+			MaxLines="8"
+			TextWrapping="Wrap"
+			VerticalContentAlignment="Top"
+			HorizontalScrollBarVisibility="Disabled"
+			VerticalScrollBarVisibility="Auto" />
+		<StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+			<Button Content="Cancel" Click="Cancel_OnClick" Padding="12,4" />
+			<Button Content="OK" Click="Save_OnClick" Padding="12,4" Margin="8,0,0,0" ToolTip="Save changes (Ctrl+Enter)" />
+		</StackPanel>
+	</Grid>
+</Window>

--- a/src/BrowserPicker.App/View/UrlEditor.xaml.cs
+++ b/src/BrowserPicker.App/View/UrlEditor.xaml.cs
@@ -1,0 +1,63 @@
+using System.Windows;
+using System.Windows.Input;
+#if DEBUG
+using JetBrains.Annotations;
+#endif
+
+namespace BrowserPicker.View;
+
+/// <summary>
+/// Interaction logic for UrlEditor.xaml
+/// </summary>
+public partial class UrlEditor
+{
+	public string? EditedUrl { get; set; }
+
+#if DEBUG
+	[UsedImplicitly]
+	public UrlEditor()
+	{
+		InitializeComponent();
+	}
+#endif
+
+	public UrlEditor(string? initialUrl)
+	{
+		EditedUrl = initialUrl;
+		InitializeComponent();
+	}
+
+	private void Window_OnLoaded(object sender, RoutedEventArgs e)
+	{
+		EditorTextBox.Focus();
+		EditorTextBox.SelectAll();
+	}
+
+	private void Save_OnClick(object sender, RoutedEventArgs e)
+	{
+		DialogResult = true;
+	}
+
+	private void Cancel_OnClick(object sender, RoutedEventArgs e)
+	{
+		DialogResult = false;
+	}
+
+	private void Window_OnPreviewKeyUp(object sender, KeyEventArgs e)
+	{
+		if (e.Key == Key.Escape)
+		{
+			e.Handled = true;
+			DialogResult = false;
+			return;
+		}
+
+		if (e.Key != Key.Enter || Keyboard.Modifiers != ModifierKeys.Control)
+		{
+			return;
+		}
+
+		e.Handled = true;
+		DialogResult = true;
+	}
+}

--- a/src/BrowserPicker.App/ViewModel/ApplicationViewModel.cs
+++ b/src/BrowserPicker.App/ViewModel/ApplicationViewModel.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Windows;
 using System.Windows.Input;
 using BrowserPicker.Framework;
+using BrowserPicker.View;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -35,6 +36,23 @@ public sealed class ApplicationViewModel : ModelBase
 	[UsedImplicitly]
 	public ApplicationViewModel()
 	{
+		if (ReferenceEquals(App.Settings, null))
+		{
+			var designSettings = ConfigurationViewModel.CreateDesignTimeSettings();
+			Url = new UrlHandler(NullLogger<UrlHandler>.Instance, "https://github.com/mortenn/BrowserPicker", designSettings);
+			force_choice = true;
+			Choices = [];
+			Configuration = new ConfigurationViewModel(designSettings, this);
+			foreach (var choice in designSettings.BrowserList
+				         .OrderBy(b => b, new BrowserSorter(designSettings))
+				         .Select(b => new BrowserViewModel(b, this)))
+			{
+				Choices.Add(choice);
+			}
+			ApplyAutoCloseOnFocusLostSetting();
+			return;
+		}
+
 		Url = new UrlHandler();
 		force_choice = true;
 		Choices = [];
@@ -310,11 +328,6 @@ public sealed class ApplicationViewModel : ModelBase
 	/// Opens the URL editor, allowing the user to modify the currently targeted URL.
 	/// </summary>
 	public ICommand Edit => new DelegateCommand(OpenURLEditor);
-
-	/// <summary>
-	/// Closes the URL editor, saving any changes made to the targeted URL.
-	/// </summary>
-	public ICommand EndEdit => new DelegateCommand(CloseURLEditor);
 	
 	/// <summary>
 	/// Gets the view model responsible for managing application configuration settings.
@@ -338,20 +351,6 @@ public sealed class ApplicationViewModel : ModelBase
 		set
 		{
 			SetProperty(ref configuration_mode, value);
-		}
-	}
-
-	/// <summary>
-	/// Gets or sets the URL being edited by the user, backing the URL editor functionality.
-	/// Changes take effect in the underlying URL handler.
-	/// </summary>
-	public string? EditURL
-	{
-		get => edit_url;
-		set
-		{
-			SetProperty(ref edit_url, value);
-			Url.UnderlyingTargetURL = value!;
 		}
 	}
 
@@ -446,21 +445,14 @@ public sealed class ApplicationViewModel : ModelBase
 	/// </summary>
 	private void OpenURLEditor()
 	{
-		EditURL = Url.UnderlyingTargetURL;
-		OnPropertyChanged(nameof(EditURL));
-	}
-
-	/// <summary>
-	/// Closes the URL editor and clears the edit state.
-	/// </summary>
-	private void CloseURLEditor()
-	{
-		if (edit_url == null)
+		var editor = new UrlEditor(Url.UnderlyingTargetURL)
 		{
-			return;
+			Owner = Application.Current?.MainWindow
+		};
+		if (editor.ShowDialog() == true)
+		{
+			Url.UnderlyingTargetURL = editor.EditedUrl;
 		}
-		edit_url = null;
-		OnPropertyChanged(nameof(EditURL));
 	}
 
 	/// <summary>
@@ -477,7 +469,6 @@ public sealed class ApplicationViewModel : ModelBase
 	}
 
 	private bool configuration_mode;
-	private string? edit_url;
 	private bool alt_pressed;
 	private readonly bool force_choice;
 	private bool pinned;

--- a/src/BrowserPicker.App/ViewModel/ConfigurationViewModel.cs
+++ b/src/BrowserPicker.App/ViewModel/ConfigurationViewModel.cs
@@ -33,19 +33,7 @@ public sealed class ConfigurationViewModel : ModelBase
 	[UsedImplicitly]
 	public ConfigurationViewModel()
 	{
-		Settings = new DesignTimeSettings
-		{
-			Defaults = [
-				new DefaultSetting(MatchType.Hostname, "github.com", Firefox.Instance.Name),
-				new DefaultSetting(MatchType.Prefix, "https://gitlab.com", Edge.Instance.Name),
-				new DefaultSetting(MatchType.Regex, @"runsafe\.no\/[0-9a-f]+$", InternetExplorer.Instance.Name),
-				new DefaultSetting(MatchType.Hostname, "gitlab.com", OperaStable.Instance.Name),
-				new DefaultSetting(MatchType.Hostname, "microsoft.com", MicrosoftEdge.Instance.Name),
-				new DefaultSetting(MatchType.Default, "", Firefox.Instance.Name)
-			],
-			BrowserList = [.. WellKnownBrowsers.List.Select(b => new BrowserModel(b, null, string.Empty))],
-			DefaultBrowser = Firefox.Instance.Name
-		};
+		Settings = CreateDesignTimeSettings();
 		Welcome = true;
 		foreach (var setting in Settings.Defaults.Where(d => d.Type != MatchType.Default))
 		{
@@ -62,6 +50,23 @@ public sealed class ConfigurationViewModel : ModelBase
 			ParentViewModel.Choices.Add(choice);
 		}
 		test_defaults_url = ParentViewModel.Url.UnderlyingTargetURL ?? ParentViewModel.Url.TargetURL;
+	}
+
+	internal static IBrowserPickerConfiguration CreateDesignTimeSettings()
+	{
+		return new DesignTimeSettings
+		{
+			Defaults = [
+				new DefaultSetting(MatchType.Hostname, "github.com", Firefox.Instance.Name),
+				new DefaultSetting(MatchType.Prefix, "https://gitlab.com", Edge.Instance.Name),
+				new DefaultSetting(MatchType.Regex, @"runsafe\.no\/[0-9a-f]+$", InternetExplorer.Instance.Name),
+				new DefaultSetting(MatchType.Hostname, "gitlab.com", OperaStable.Instance.Name),
+				new DefaultSetting(MatchType.Hostname, "microsoft.com", MicrosoftEdge.Instance.Name),
+				new DefaultSetting(MatchType.Default, "", Firefox.Instance.Name)
+			],
+			BrowserList = [.. WellKnownBrowsers.List.Select(b => new BrowserModel(b, null, string.Empty))],
+			DefaultBrowser = Firefox.Instance.Name
+		};
 	}
 
 	private sealed class DesignTimeSettings : IBrowserPickerConfiguration


### PR DESCRIPTION
## Summary
- move URL editing into a modal dialog so changes are only applied after confirmation
- remove the old inline editor plumbing from the picker view and disable the Fluent clear button in the dialog textbox
- harden design-time initialization so the Visual Studio XAML designer works when app settings are unavailable

## Test plan
- [x] Build `src/BrowserPicker.App/BrowserPicker.App.csproj` with `-p:Version=1.0.0`
- [x] Verify the URL editor no longer updates the main window URL until OK is pressed
- [x] Verify the dialog no longer shows the embedded clear button
- [x] Verify the XAML designer loads without the earlier null-reference failures

EOF