### PR TITLE
Picker: omnibox URL bar, width cap, and wrapped URL

### DIFF
--- a/src/BrowserPicker.UI/App.xaml
+++ b/src/BrowserPicker.UI/App.xaml
@@ -9,9 +9,12 @@
                 <ResourceDictionary Source="Resources/ResourceDictionary.xaml" />
                 <!-- Provide baseline theme brushes so design-time previews can resolve DynamicResource bindings. -->
                 <ResourceDictionary>
-                    <SolidColorBrush x:Key="{x:Static ui:App.ContentBackgroundBrushKey}" Color="#2D2D2D" />
-                    <SolidColorBrush x:Key="{x:Static ui:App.ContentBackgroundSemiTransparentBrushKey}" Color="#E62D2D2D" />
-                    <SolidColorBrush x:Key="{x:Static ui:App.ContentForegroundBrushKey}" Color="White" />
+                    <SolidColorBrush x:Key="{x:Static app:App.ContentBackgroundBrushKey}" Color="#2D2D2D" />
+                    <SolidColorBrush x:Key="{x:Static app:App.ContentBackgroundSemiTransparentBrushKey}" Color="#E62D2D2D" />
+                    <SolidColorBrush x:Key="{x:Static app:App.ContentForegroundBrushKey}" Color="White" />
+                    <SolidColorBrush x:Key="{x:Static app:App.UrlBarBackgroundBrushKey}" Color="White" />
+                    <SolidColorBrush x:Key="{x:Static app:App.UrlBarForegroundBrushKey}" Color="#1A1A1A" />
+                    <SolidColorBrush x:Key="{x:Static app:App.UrlBarBorderBrushKey}" Color="#B0B0B0" />
                 </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>

--- a/src/BrowserPicker.UI/App.xaml.cs
+++ b/src/BrowserPicker.UI/App.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -30,6 +30,11 @@ public partial class App
 	/// <summary>Semi-transparent content background used when transparency is enabled (DisableTransparency = false).</summary>
 	public const string ContentBackgroundSemiTransparentBrushKey = "ContentBackgroundSemiTransparentBrush";
 	public const string ContentForegroundBrushKey = "ContentForegroundBrush";
+
+	/// <summary>Address-bar strip behind favicon + URL (browser-like; stays light in both themes so dark favicons read clearly).</summary>
+	public const string UrlBarBackgroundBrushKey = "UrlBarBackgroundBrush";
+	public const string UrlBarForegroundBrushKey = "UrlBarForegroundBrush";
+	public const string UrlBarBorderBrushKey = "UrlBarBorderBrush";
 
 	private class InvalidUTF8Patch : EncodingProvider
 	{
@@ -172,12 +177,18 @@ public partial class App
 			d[ContentBackgroundBrushKey] = new SolidColorBrush(Color.FromRgb(0xEB, 0xEB, 0xEB));
 			d[ContentBackgroundSemiTransparentBrushKey] = new SolidColorBrush(Color.FromArgb(semiTransparentAlpha, 0xEB, 0xEB, 0xEB));
 			d[ContentForegroundBrushKey] = new SolidColorBrush(Colors.Black);
+			d[UrlBarBackgroundBrushKey] = new SolidColorBrush(Colors.White);
+			d[UrlBarForegroundBrushKey] = new SolidColorBrush(Color.FromRgb(0x1A, 0x1A, 0x1A));
+			d[UrlBarBorderBrushKey] = new SolidColorBrush(Color.FromRgb(0xC8, 0xC8, 0xC8));
 		}
 		else
 		{
 			d[ContentBackgroundBrushKey] = new SolidColorBrush(Color.FromRgb(0x2D, 0x2D, 0x2D));
 			d[ContentBackgroundSemiTransparentBrushKey] = new SolidColorBrush(Color.FromArgb(semiTransparentAlpha, 0x2D, 0x2D, 0x2D));
 			d[ContentForegroundBrushKey] = new SolidColorBrush(Colors.White);
+			d[UrlBarBackgroundBrushKey] = new SolidColorBrush(Colors.White);
+			d[UrlBarForegroundBrushKey] = new SolidColorBrush(Color.FromRgb(0x1A, 0x1A, 0x1A));
+			d[UrlBarBorderBrushKey] = new SolidColorBrush(Color.FromRgb(0xB0, 0xB0, 0xB0));
 		}
 		return d;
 	}

--- a/src/BrowserPicker.UI/Converters/PickerUrlBarMaxWidthConverter.cs
+++ b/src/BrowserPicker.UI/Converters/PickerUrlBarMaxWidthConverter.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace BrowserPicker.UI.Converters;
+
+/// <summary>
+/// Caps the picker URL bar width during <see cref="SizeToContent"/> layout so a long URL does not force the
+/// window to the full text width. Once the window has an <see cref="FrameworkElement.ActualWidth"/>, the bar
+/// tracks it (still limited to the work area).
+/// </summary>
+public sealed class PickerUrlBarMaxWidthConverter : IValueConverter
+{
+	public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+	{
+		const double subtractFromWindow = 36;
+		var workAreaCap = Math.Max(280, SystemParameters.WorkArea.Width - 24);
+		const double initialMeasureCap = 720;
+
+		if (value is double w && w > 1 && !double.IsNaN(w) && !double.IsInfinity(w))
+			return Math.Min(w - subtractFromWindow, workAreaCap);
+
+		return Math.Min(initialMeasureCap, workAreaCap);
+	}
+
+	public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+		throw new NotSupportedException();
+}

--- a/src/BrowserPicker.UI/Views/BrowserList.xaml
+++ b/src/BrowserPicker.UI/Views/BrowserList.xaml
@@ -14,15 +14,18 @@
 			<converters:IconFileToImageConverter x:Key="IconConverter" />
 			<converters:ContainerColorConverter x:Key="ContainerColorConverter" />
 			<converters:ContainerIconConverter x:Key="ContainerIconConverter" />
+			<converters:PickerUrlBarMaxWidthConverter x:Key="PickerUrlBarMaxWidthConverter" />
 		</ResourceDictionary>
 	</UserControl.Resources>
-	<Grid MinWidth="350">
+	<Grid
+		MinWidth="350"
+		MaxWidth="{Binding ActualWidth, RelativeSource={RelativeSource AncestorType=Window}, Converter={StaticResource PickerUrlBarMaxWidthConverter}}">
 		<Grid.RowDefinitions>
 			<RowDefinition Height="Auto" />
 			<RowDefinition Height="*" />
 			<RowDefinition Height="Auto" />
 		</Grid.RowDefinitions>
-		<StackPanel Orientation="Vertical" Margin="0,0,50,0">
+		<StackPanel Orientation="Vertical">
 			<StackPanel Orientation="Horizontal">
 				<Image Source="{DynamicResource DefaultIcon}" Height="16" Margin="5" />
 				<TextBlock Margin="0,5">
@@ -80,11 +83,40 @@
 					</TextBlock.Style>
 				</TextBlock>
 			</StackPanel>
-			<Border Background="{DynamicResource {x:Static ui:App.ContentBackgroundBrushKey}}" CornerRadius="5" Padding="2" Margin="2">
-				<TextBlock Foreground="{DynamicResource {x:Static ui:App.ContentForegroundBrushKey}}" TextWrapping="Wrap" TextTrimming="CharacterEllipsis" MaxWidth="380" MaxHeight="100">
-					<Image Source="{Binding Url.FavIcon}" Height="16" Width="16" Margin="0,-3" />
-					<Run Text="{Binding Url.DisplayURL, Mode=OneWay}" />
-				</TextBlock>
+			<!-- Wrapped URL (omnibox-style bar); MaxHeight caps height so absurd URLs do not dominate the picker. Tooltip shows full string. -->
+			<Border
+				HorizontalAlignment="Stretch"
+				Background="{DynamicResource {x:Static ui:App.UrlBarBackgroundBrushKey}}"
+				BorderBrush="{DynamicResource {x:Static ui:App.UrlBarBorderBrushKey}}"
+				BorderThickness="1"
+				CornerRadius="5"
+				Padding="6,4"
+				Margin="2"
+				ToolTip="{Binding Url.DisplayURL}">
+				<Grid>
+					<Grid.ColumnDefinitions>
+						<ColumnDefinition Width="Auto" />
+						<ColumnDefinition Width="*" />
+					</Grid.ColumnDefinitions>
+					<Image
+						Grid.Column="0"
+						Source="{Binding Url.FavIcon}"
+						Width="16"
+						Height="16"
+						VerticalAlignment="Top"
+						Margin="0,2,6,0" />
+					<TextBlock
+						Grid.Column="1"
+						MinWidth="0"
+						HorizontalAlignment="Stretch"
+						VerticalAlignment="Top"
+						Foreground="{DynamicResource {x:Static ui:App.UrlBarForegroundBrushKey}}"
+						Text="{Binding Url.DisplayURL, Mode=OneWay}"
+						TextWrapping="Wrap"
+						TextTrimming="CharacterEllipsis"
+						MaxHeight="76"
+						TextAlignment="Left" />
+				</Grid>
 			</Border>
 		</StackPanel>
 		<ScrollViewer x:Name="BrowserListScroll" Grid.Row="1" HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto" SizeChanged="BrowserListScroll_SizeChanged">


### PR DESCRIPTION
## Summary

Restores a browser-like light strip for the favicon + URL on the picker, keeps long URLs from blowing out `SizeToContent` window width, and shows the URL wrapped (with a height cap and ellipsis) instead of a single truncated line.

## Changes

- **Theme:** `UrlBar*` dynamic brushes in `App.xaml.cs` (and design-time entries in `App.xaml`) so the address area stays a light omnibox in both themes.
- **Layout:** `PickerUrlBarMaxWidthConverter` caps the root `Grid` `MaxWidth` from the window width / work area so measure pass does not use the full text width.
- **URL text:** Grid + top-aligned favicon; `TextWrapping="Wrap"`, `MaxHeight` ~4 lines, `TextTrimming` for overflow; tooltip still shows the full URL.

## Verification

- `dotnet build src/BrowserPicker.UI/BrowserPicker.UI.csproj -p:Version=1.0.0 -p:Platform=x64`
- Manual check in VS / XAML Hot Reload with a very long URL (wrapping + ellipsis on last line).
