### PR TITLE
Document XAML Styler line ending expectations

### DIFF
--- a/docs/xaml-styler.md
+++ b/docs/xaml-styler.md
@@ -27,3 +27,7 @@ dotnet xstyler --recursive --directory .
 
 This reformats every `*.xaml` file in the repository according to the shared
 `Settings.XamlStyler` configuration.
+
+The repository also declares formatter-specific line ending expectations in
+`.gitattributes`, so `*.xaml` files follow the conventions expected by XAML
+Styler on Windows.


### PR DESCRIPTION
## Summary
- document that the repository uses `.gitattributes` to preserve the line ending conventions XAML Styler expects on Windows
- provide a small smoke-test PR to verify the post-issue-258 PR validation workflow on a normal branch
- keep the change limited to docs so the PR is low risk

## Test plan
- [ ] confirm the PR shows only the dedicated PR validation check
- [ ] confirm the PR validation run passes
- [ ] confirm the PR validation comment workflow posts or updates the summary comment