### PR TITLE
Add manual TLS connection check

### DIFF
--- a/schemas/browserpicker-settings.schema.json
+++ b/schemas/browserpicker-settings.schema.json
@@ -46,6 +46,15 @@
     "FaviconsForDefaults": {
       "type": "boolean"
     },
+    "CheckCertificateRecords": {
+      "type": "boolean"
+    },
+    "HideManualConnectionCheck": {
+      "type": "boolean"
+    },
+    "SkipConnectionCheckConfirmation": {
+      "type": "boolean"
+    },
     "AutoCloseOnFocusLost": {
       "type": "boolean"
     },

--- a/src/BrowserPicker.Common/BrowserPicker.Common.csproj
+++ b/src/BrowserPicker.Common/BrowserPicker.Common.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
+    <PackageReference Include="DnsClient" />
     <PackageReference Include="JetBrains.Annotations" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
   </ItemGroup>

--- a/src/BrowserPicker.Common/ISecuritySettings.cs
+++ b/src/BrowserPicker.Common/ISecuritySettings.cs
@@ -24,4 +24,19 @@ public interface ISecuritySettings
 	/// When true, only probes favicons for URLs matching a Defaults rule.
 	/// </summary>
 	bool FaviconsForDefaults { get; set; }
+
+	/// <summary>
+	/// When true, explicit certificate checks also inspect DNS CAA records and certificate transparency evidence.
+	/// </summary>
+	bool CheckCertificateRecords { get; set; }
+
+	/// <summary>
+	/// When true, hides the manual connection check action from the picker.
+	/// </summary>
+	bool HideManualConnectionCheck { get; set; }
+
+	/// <summary>
+	/// When true, manual connection checks start immediately without showing the confirmation prompt.
+	/// </summary>
+	bool SkipConnectionCheckConfirmation { get; set; }
 }

--- a/src/BrowserPicker.Common/SecurityOptions.cs
+++ b/src/BrowserPicker.Common/SecurityOptions.cs
@@ -6,6 +6,9 @@ public sealed record SecurityOptions
 	public bool RedirectsKnownOnly { get; set; }
 	public bool ProbeFavicons { get; set; }
 	public bool FaviconsForDefaults { get; set; }
+	public bool CheckCertificateRecords { get; set; }
+	public bool HideManualConnectionCheck { get; set; }
+	public bool SkipConnectionCheckConfirmation { get; set; }
 
 	public static SecurityOptions Default =>
 		new()
@@ -14,6 +17,9 @@ public sealed record SecurityOptions
 			RedirectsKnownOnly = true,
 			ProbeFavicons = true,
 			FaviconsForDefaults = true,
+			CheckCertificateRecords = true,
+			HideManualConnectionCheck = false,
+			SkipConnectionCheckConfirmation = false,
 		};
 
 	public static SecurityOptions MaxPrivacy =>
@@ -23,6 +29,9 @@ public sealed record SecurityOptions
 			RedirectsKnownOnly = true,
 			ProbeFavicons = false,
 			FaviconsForDefaults = true,
+			CheckCertificateRecords = false,
+			HideManualConnectionCheck = true,
+			SkipConnectionCheckConfirmation = false,
 		};
 
 	public static SecurityOptions EnableAll =>
@@ -32,6 +41,9 @@ public sealed record SecurityOptions
 			RedirectsKnownOnly = false,
 			ProbeFavicons = true,
 			FaviconsForDefaults = false,
+			CheckCertificateRecords = true,
+			HideManualConnectionCheck = false,
+			SkipConnectionCheckConfirmation = true,
 		};
 }
 
@@ -45,6 +57,9 @@ public static class SecuritySettingsExtensions
 			RedirectsKnownOnly = settings.RedirectsKnownOnly,
 			ProbeFavicons = settings.ProbeFavicons,
 			FaviconsForDefaults = settings.FaviconsForDefaults,
+			CheckCertificateRecords = settings.CheckCertificateRecords,
+			HideManualConnectionCheck = settings.HideManualConnectionCheck,
+			SkipConnectionCheckConfirmation = settings.SkipConnectionCheckConfirmation,
 		};
 	}
 
@@ -54,5 +69,8 @@ public static class SecuritySettingsExtensions
 		settings.RedirectsKnownOnly = options.RedirectsKnownOnly;
 		settings.ProbeFavicons = options.ProbeFavicons;
 		settings.FaviconsForDefaults = options.FaviconsForDefaults;
+		settings.CheckCertificateRecords = options.CheckCertificateRecords;
+		settings.HideManualConnectionCheck = options.HideManualConnectionCheck;
+		settings.SkipConnectionCheckConfirmation = options.SkipConnectionCheckConfirmation;
 	}
 }

--- a/src/BrowserPicker.Common/SerializableSettings.cs
+++ b/src/BrowserPicker.Common/SerializableSettings.cs
@@ -32,6 +32,9 @@ public sealed class SerializableSettings : IApplicationSettings
 		RedirectsKnownOnly = applicationSettings.RedirectsKnownOnly;
 		ProbeFavicons = applicationSettings.ProbeFavicons;
 		FaviconsForDefaults = applicationSettings.FaviconsForDefaults;
+		CheckCertificateRecords = applicationSettings.CheckCertificateRecords;
+		HideManualConnectionCheck = applicationSettings.HideManualConnectionCheck;
+		SkipConnectionCheckConfirmation = applicationSettings.SkipConnectionCheckConfirmation;
 		UrlShorteners = applicationSettings.UrlShorteners;
 		BrowserList = [.. applicationSettings.BrowserList.Where(b => !b.Removed)];
 		Defaults = [.. applicationSettings.Defaults.Where(d => !d.Deleted && !string.IsNullOrWhiteSpace(d.Browser))];
@@ -96,6 +99,15 @@ public sealed class SerializableSettings : IApplicationSettings
 
 	/// <inheritdoc />
 	public bool FaviconsForDefaults { get; set; } = true;
+
+	/// <inheritdoc />
+	public bool CheckCertificateRecords { get; set; } = true;
+
+	/// <inheritdoc />
+	public bool HideManualConnectionCheck { get; set; }
+
+	/// <inheritdoc />
+	public bool SkipConnectionCheckConfirmation { get; set; }
 
 	/// <summary>
 	/// When true, the picker closes itself when it loses focus. Defaults to being enabled.

--- a/src/BrowserPicker.Common/TlsCertificateSummary.cs
+++ b/src/BrowserPicker.Common/TlsCertificateSummary.cs
@@ -1,0 +1,597 @@
+using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.Formats.Asn1;
+using System.Linq;
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using DnsClient;
+
+namespace BrowserPicker.Common;
+
+public sealed record TlsCertificateSummary(
+	Uri Uri,
+	string Host,
+	int Port,
+	string Subject,
+	string Issuer,
+	DateTimeOffset ValidFrom,
+	DateTimeOffset Expires,
+	string? CommonName,
+	IReadOnlyList<string> SubjectAlternativeNames,
+	bool HostNameMatchesCertificate,
+	SslPolicyErrors PolicyErrors,
+	IReadOnlyList<string> ChainStatus,
+	SslProtocols Protocol,
+	TlsCipherSuite? CipherSuite,
+	bool CertificateRecordsChecked,
+	IReadOnlyList<string> CaaRecords,
+	string CertificateTransparencyStatus
+)
+{
+	private const int DefaultHttpsPort = 443;
+	private const int DefaultTimeoutMilliseconds = 5000;
+	private const string EmbeddedSctOid = "1.3.6.1.4.1.11129.2.4.2";
+
+	public string ValidationText => FormatValidation();
+
+	public string HostMatchText => $"{(HostNameMatchesCertificate ? "Yes" : "No")} ({Host})";
+
+	public string ValidFromText => $"{ValidFrom.LocalDateTime:g}";
+
+	public string ExpiresText => $"{Expires.LocalDateTime:g}";
+
+	public string? SubjectAlternativeNamesText =>
+		SubjectAlternativeNames.Count == 0 ? null : FormatNames(SubjectAlternativeNames);
+
+	public string? ProtocolText => Protocol == SslProtocols.None ? null : Protocol.ToString();
+
+	public string? CipherStrengthText => CipherSuite == null ? null : FormatCipherStrength();
+
+	public string? CipherSuiteText => CipherSuite?.ToString();
+
+	public string ChainText => FormatChainStatus();
+
+	public string CertificateAuthorityAuthorizationText =>
+		CertificateRecordsChecked ? FormatCaaStatus() : "Not checked";
+
+	public string CertificateTransparencyText =>
+		CertificateRecordsChecked ? CertificateTransparencyStatus : "Not checked";
+
+	public static bool TryCreateTarget(string? targetUrl, out Uri uri, out string errorMessage)
+	{
+		if (string.IsNullOrWhiteSpace(targetUrl))
+		{
+			uri = null!;
+			errorMessage = "No URL is available to check.";
+			return false;
+		}
+
+		if (!Uri.TryCreate(targetUrl, UriKind.Absolute, out uri!))
+		{
+			errorMessage = "This is not an absolute URL, so there is no TLS host to check.";
+			return false;
+		}
+
+		if (!string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+		{
+			errorMessage =
+				$"TLS certificate checks are only available for HTTPS URLs. This URL uses {uri.Scheme.ToUpperInvariant()}.";
+			return false;
+		}
+
+		if (string.IsNullOrWhiteSpace(uri.Host))
+		{
+			errorMessage = "This URL does not include a host name to check.";
+			return false;
+		}
+
+		errorMessage = string.Empty;
+		return true;
+	}
+
+	public static Task<TlsCertificateSummary> InspectAsync(Uri uri, CancellationToken cancellationToken) =>
+		InspectAsync(uri, includeCertificateRecords: true, cancellationToken);
+
+	public static Task<TlsCertificateSummary> InspectAsync(
+		Uri uri,
+		bool includeCertificateRecords,
+		CancellationToken cancellationToken
+	) =>
+		InspectAsync(
+			uri,
+			includeCertificateRecords,
+			TimeSpan.FromMilliseconds(DefaultTimeoutMilliseconds),
+			cancellationToken
+		);
+
+	public static async Task<TlsCertificateSummary> InspectAsync(
+		Uri uri,
+		bool includeCertificateRecords,
+		TimeSpan timeout,
+		CancellationToken cancellationToken
+	)
+	{
+		if (!TryCreateTarget(uri.ToString(), out var targetUri, out var errorMessage))
+		{
+			throw new ArgumentException(errorMessage, nameof(uri));
+		}
+
+		using var timeoutSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+		timeoutSource.CancelAfter(timeout);
+
+		using var client = new TcpClient();
+		await client.ConnectAsync(targetUri.Host, GetPort(targetUri), timeoutSource.Token).ConfigureAwait(false);
+
+		await using var networkStream = client.GetStream();
+		X509Certificate2? certificate = null;
+		var policyErrors = SslPolicyErrors.None;
+		var chainStatus = Array.Empty<string>();
+
+		using var sslStream = new SslStream(
+			networkStream,
+			leaveInnerStreamOpen: false,
+			(_, remoteCertificate, chain, errors) =>
+			{
+				policyErrors = errors;
+				certificate = remoteCertificate == null ? null : new X509Certificate2(remoteCertificate);
+				chainStatus =
+				[
+					.. chain?.ChainStatus.Select(status =>
+						string.IsNullOrWhiteSpace(status.StatusInformation)
+							? status.Status.ToString()
+							: $"{status.Status}: {status.StatusInformation.Trim()}"
+					)
+						?? [],
+				];
+				return true;
+			}
+		);
+
+		await sslStream
+			.AuthenticateAsClientAsync(
+				new SslClientAuthenticationOptions
+				{
+					TargetHost = targetUri.Host,
+					CertificateRevocationCheckMode = X509RevocationMode.NoCheck,
+					EnabledSslProtocols = SslProtocols.None,
+				},
+				timeoutSource.Token
+			)
+			.ConfigureAwait(false);
+
+		certificate ??= sslStream.RemoteCertificate == null ? null : new X509Certificate2(sslStream.RemoteCertificate);
+		if (certificate == null)
+		{
+			throw new InvalidOperationException("The TLS handshake completed without a certificate.");
+		}
+
+		return FromCertificate(
+			targetUri,
+			certificate,
+			policyErrors,
+			chainStatus,
+			sslStream.SslProtocol,
+			sslStream.NegotiatedCipherSuite,
+			includeCertificateRecords,
+			includeCertificateRecords
+				? await GetCaaRecordsAsync(targetUri.Host, timeoutSource.Token).ConfigureAwait(false)
+				: [],
+			includeCertificateRecords ? GetCertificateTransparencyStatus(certificate) : "Not checked"
+		);
+	}
+
+	public static TlsCertificateSummary FromCertificate(
+		Uri uri,
+		X509Certificate2 certificate,
+		SslPolicyErrors policyErrors,
+		IReadOnlyList<string> chainStatus,
+		SslProtocols protocol = SslProtocols.None,
+		TlsCipherSuite? cipherSuite = null,
+		bool certificateRecordsChecked = true,
+		IReadOnlyList<string>? caaRecords = null,
+		string? certificateTransparencyStatus = null
+	)
+	{
+		var names = GetSubjectAlternativeDnsNames(certificate);
+		var commonName = certificate.GetNameInfo(X509NameType.SimpleName, forIssuer: false);
+		var matchNames = names.Count > 0 ? names : [commonName];
+
+		return new TlsCertificateSummary(
+			uri,
+			uri.Host,
+			GetPort(uri),
+			certificate.Subject,
+			certificate.Issuer,
+			new DateTimeOffset(certificate.NotBefore),
+			new DateTimeOffset(certificate.NotAfter),
+			string.IsNullOrWhiteSpace(commonName) ? null : commonName,
+			names,
+			matchNames.Any(name => CertificateNameMatchesHost(name, uri.Host)),
+			policyErrors,
+			chainStatus,
+			protocol,
+			cipherSuite,
+			certificateRecordsChecked,
+			caaRecords ?? [],
+			certificateRecordsChecked
+				? certificateTransparencyStatus ?? GetCertificateTransparencyStatus(certificate)
+				: certificateTransparencyStatus ?? "Not checked"
+		);
+	}
+
+	public string ToDisplayText()
+	{
+		var builder = new StringBuilder()
+			.AppendLine($"Connection check for {Uri}")
+			.AppendLine()
+			.AppendLine(
+				CertificateRecordsChecked
+					? $"Privacy: this check contacted the target host ({Host}:{Port}) and may have queried DNS for CAA records. The website, DNS resolver, and network proxies may see this activity."
+					: $"Privacy: this check contacted only the target host ({Host}:{Port}). The website and network proxies may see the connection."
+			)
+			.AppendLine()
+			.AppendLine($"Validation: {FormatValidation()}")
+			.AppendLine($"Host match: {(HostNameMatchesCertificate ? "Yes" : "No")} ({Host})")
+			.AppendLine($"Subject: {Subject}")
+			.AppendLine($"Issuer: {Issuer}")
+			.AppendLine($"Valid from: {ValidFrom.LocalDateTime:g}")
+			.AppendLine($"Expires: {Expires.LocalDateTime:g}");
+
+		if (!string.IsNullOrWhiteSpace(CommonName))
+		{
+			builder.AppendLine($"Common name: {CommonName}");
+		}
+
+		if (SubjectAlternativeNames.Count > 0)
+		{
+			builder.AppendLine($"SAN DNS names: {FormatNames(SubjectAlternativeNames)}");
+		}
+
+		if (Protocol != SslProtocols.None)
+		{
+			builder.AppendLine($"Protocol: {Protocol}");
+		}
+
+		if (CipherSuite != null)
+		{
+			builder.AppendLine($"Cipher strength: {FormatCipherStrength()}");
+			builder.AppendLine($"Cipher suite: {CipherSuite}");
+		}
+
+		builder.AppendLine($"Chain: {FormatChainStatus()}");
+		if (CertificateRecordsChecked)
+		{
+			builder.AppendLine($"CAA: {FormatCaaStatus()}");
+			builder.AppendLine($"Certificate transparency: {CertificateTransparencyStatus}");
+		}
+		else
+		{
+			builder.AppendLine("CAA / certificate transparency: Not checked");
+		}
+		return builder.ToString().TrimEnd();
+	}
+
+	private string FormatValidation()
+	{
+		return PolicyErrors == SslPolicyErrors.None ? "Valid" : $"Problems found ({PolicyErrors})";
+	}
+
+	private string FormatChainStatus()
+	{
+		return ChainStatus.Count == 0 ? "OK" : string.Join("; ", ChainStatus);
+	}
+
+	private string FormatCaaStatus()
+	{
+		if (CaaRecords.Count == 0)
+		{
+			return "None";
+		}
+
+		return CaaRecords.Any(record => CaaRecordMatchesIssuer(record, Issuer)) ? "Aligned" : "Unaligned";
+	}
+
+	private string FormatCipherStrength()
+	{
+		var protocolValue = (int)Protocol;
+		if (protocolValue is 12 or 48 or 192 or 768)
+		{
+			return "Insecure. This connection used an obsolete TLS protocol.";
+		}
+
+		if (CipherSuite == null)
+		{
+			return "Unknown. BrowserPicker could not read the negotiated cipher suite.";
+		}
+
+		var suite = CipherSuite.Value.ToString().ToUpperInvariant();
+		if (ContainsAny(suite, "NULL", "EXPORT", "RC4", "3DES", "DES", "_CBC_", "_MD5"))
+		{
+			return "Weak. The negotiated cipher uses older cryptography.";
+		}
+
+		if (ContainsAny(suite, "MLKEM", "KYBER", "HYBRID"))
+		{
+			return "Strong. Modern encryption with a post-quantum key exchange signal.";
+		}
+
+		if (Protocol == SslProtocols.Tls13 || ContainsAny(suite, "_GCM_", "CHACHA20_POLY1305"))
+		{
+			return "Strong classical (not post-quantum). Modern TLS encryption; no post-quantum key exchange was reported.";
+		}
+
+		return "Not post-quantum. No obvious weak cipher was reported, but this is not a modern post-quantum TLS signal.";
+	}
+
+	private static bool ContainsAny(string value, params string[] tokens)
+	{
+		return tokens.Any(token => value.Contains(token, StringComparison.Ordinal));
+	}
+
+	private static int GetPort(Uri uri)
+	{
+		return uri.IsDefaultPort ? DefaultHttpsPort : uri.Port;
+	}
+
+	private static string FormatNames(IReadOnlyList<string> names)
+	{
+		const int maxNames = 12;
+		if (names.Count <= maxNames)
+		{
+			return string.Join(", ", names);
+		}
+
+		return $"{string.Join(", ", names.Take(maxNames))}, and {names.Count - maxNames} more";
+	}
+
+	private static bool CertificateNameMatchesHost(string certificateName, string host)
+	{
+		if (string.IsNullOrWhiteSpace(certificateName) || string.IsNullOrWhiteSpace(host))
+		{
+			return false;
+		}
+
+		var normalizedName = certificateName.TrimEnd('.');
+		var normalizedHost = host.TrimEnd('.');
+		if (!normalizedName.StartsWith("*.", StringComparison.Ordinal))
+		{
+			return string.Equals(normalizedName, normalizedHost, StringComparison.OrdinalIgnoreCase);
+		}
+
+		var suffix = normalizedName[1..];
+		return normalizedHost.EndsWith(suffix, StringComparison.OrdinalIgnoreCase)
+			&& normalizedHost.Length > suffix.Length
+			&& normalizedHost[..^suffix.Length].Count(c => c == '.') == 0;
+	}
+
+	private static bool CaaRecordMatchesIssuer(string record, string issuer)
+	{
+		if (!TryGetCaaIssuer(record, out var caaIssuer))
+		{
+			return false;
+		}
+
+		var normalizedIssuer = NormalizeCertificateAuthorityName(issuer);
+		var normalizedCaaIssuer = NormalizeCertificateAuthorityName(caaIssuer);
+		return normalizedCaaIssuer.Length > 0
+			&& normalizedIssuer.Contains(normalizedCaaIssuer, StringComparison.Ordinal);
+	}
+
+	private static bool TryGetCaaIssuer(string record, out string issuer)
+	{
+		issuer = string.Empty;
+		var fields = record.Split(' ', 3, StringSplitOptions.RemoveEmptyEntries);
+		if (fields.Length < 3 || !fields[1].StartsWith("issue", StringComparison.OrdinalIgnoreCase))
+		{
+			return false;
+		}
+
+		issuer = fields[2].Trim().Trim('"');
+		var parameterStart = issuer.IndexOf(';', StringComparison.Ordinal);
+		if (parameterStart >= 0)
+		{
+			issuer = issuer[..parameterStart];
+		}
+
+		return !string.IsNullOrWhiteSpace(issuer);
+	}
+
+	private static string NormalizeCertificateAuthorityName(string value)
+	{
+		var hostLabels = value.Split('.', StringSplitOptions.RemoveEmptyEntries);
+		if (hostLabels.Length > 1)
+		{
+			value = hostLabels[^2];
+		}
+
+		return new string(value.Where(char.IsLetterOrDigit).Select(char.ToLowerInvariant).ToArray());
+	}
+
+	private static IReadOnlyList<string> GetSubjectAlternativeDnsNames(X509Certificate2 certificate)
+	{
+		foreach (var extension in certificate.Extensions)
+		{
+			if (extension.Oid?.Value == "2.5.29.17")
+			{
+				return ReadSubjectAlternativeDnsNames(extension.RawData);
+			}
+		}
+
+		return [];
+	}
+
+	private static async Task<IReadOnlyList<string>> GetCaaRecordsAsync(
+		string host,
+		CancellationToken cancellationToken
+	)
+	{
+		try
+		{
+			var client = new LookupClient();
+			foreach (var name in EnumerateCaaLookupNames(host))
+			{
+				var result = await client
+					.QueryAsync(name, QueryType.CAA, QueryClass.IN, cancellationToken)
+					.ConfigureAwait(false);
+				var records = result.Answers.CaaRecords().ToArray();
+				if (records.Length > 0)
+				{
+					return
+					[
+						.. records.Select(record =>
+							string.IsNullOrWhiteSpace(record.Value)
+								? $"{record.Flags} {record.Tag}"
+								: $"{record.Flags} {record.Tag} \"{record.Value}\""
+						),
+					];
+				}
+			}
+
+			return [];
+		}
+		catch (DnsResponseException ex)
+		{
+			return [$"Lookup failed: {ex.Message}"];
+		}
+		catch (SocketException ex)
+		{
+			return [$"Lookup failed: {ex.Message}"];
+		}
+	}
+
+	private static IEnumerable<string> EnumerateCaaLookupNames(string host)
+	{
+		var labels = host.TrimEnd('.').Split('.', StringSplitOptions.RemoveEmptyEntries);
+		for (var start = 0; start < labels.Length - 1; start++)
+		{
+			yield return string.Join('.', labels.Skip(start));
+		}
+	}
+
+	private static string GetCertificateTransparencyStatus(X509Certificate2 certificate)
+	{
+		var extension = certificate.Extensions.FirstOrDefault(extension => extension.Oid?.Value == EmbeddedSctOid);
+		if (extension == null)
+		{
+			return "No embedded SCT extension found";
+		}
+
+		var scts = ReadEmbeddedSignedCertificateTimestamps(extension.RawData);
+		if (scts.Count == 0)
+		{
+			return "Inconclusive. The certificate has a transparency extension, but BrowserPicker could not read its timestamps.";
+		}
+
+		var newest = scts.Max(sct => sct.Timestamp);
+		return $"Looks normal. The certificate includes {scts.Count} transparency timestamp{Pluralize(scts.Count)}, newest {newest:yyyy-MM-dd}.";
+	}
+
+	private static IReadOnlyList<SignedCertificateTimestamp> ReadEmbeddedSignedCertificateTimestamps(byte[] rawData)
+	{
+		var data = UnwrapSctExtension(rawData);
+		if (data.Length < 2)
+		{
+			return [];
+		}
+
+		var listLength = BinaryPrimitives.ReadUInt16BigEndian(data[..2]);
+		var end = Math.Min(data.Length, listLength + 2);
+		var offset = 2;
+		var scts = new List<SignedCertificateTimestamp>();
+		while (offset + 2 <= end)
+		{
+			var sctLength = BinaryPrimitives.ReadUInt16BigEndian(data.Slice(offset, 2));
+			offset += 2;
+			if (offset + sctLength > end)
+			{
+				break;
+			}
+
+			if (TryReadSignedCertificateTimestamp(data.Slice(offset, sctLength), out var sct))
+			{
+				scts.Add(sct);
+			}
+			offset += sctLength;
+		}
+
+		return scts;
+	}
+
+	private static ReadOnlySpan<byte> UnwrapSctExtension(byte[] rawData)
+	{
+		try
+		{
+			var reader = new AsnReader(rawData, AsnEncodingRules.DER);
+			var octets = reader.ReadOctetString();
+			return octets;
+		}
+		catch (AsnContentException)
+		{
+			return rawData;
+		}
+	}
+
+	private static bool TryReadSignedCertificateTimestamp(ReadOnlySpan<byte> data, out SignedCertificateTimestamp sct)
+	{
+		sct = default;
+		const int minimumLength = 1 + 32 + 8 + 2 + 2 + 2;
+		if (data.Length < minimumLength)
+		{
+			return false;
+		}
+
+		var offset = 0;
+		offset++;
+		offset += 32;
+		var timestampMilliseconds = BinaryPrimitives.ReadUInt64BigEndian(data.Slice(offset, 8));
+		offset += 8;
+		var extensionsLength = BinaryPrimitives.ReadUInt16BigEndian(data.Slice(offset, 2));
+		offset += 2 + extensionsLength;
+		if (offset + 4 > data.Length)
+		{
+			return false;
+		}
+
+		offset += 2;
+		var signatureLength = BinaryPrimitives.ReadUInt16BigEndian(data.Slice(offset, 2));
+		offset += 2;
+		if (offset + signatureLength > data.Length)
+		{
+			return false;
+		}
+
+		sct = new SignedCertificateTimestamp(DateTimeOffset.FromUnixTimeMilliseconds((long)timestampMilliseconds));
+		return true;
+	}
+
+	private static string Pluralize(int count) => count == 1 ? string.Empty : "s";
+
+	private readonly record struct SignedCertificateTimestamp(DateTimeOffset Timestamp);
+
+	private static IReadOnlyList<string> ReadSubjectAlternativeDnsNames(byte[] rawData)
+	{
+		var names = new List<string>();
+		var reader = new AsnReader(rawData, AsnEncodingRules.DER);
+		var sequence = reader.ReadSequence();
+		var dnsNameTag = new Asn1Tag(TagClass.ContextSpecific, 2);
+
+		while (sequence.HasData)
+		{
+			if (sequence.PeekTag().HasSameClassAndValue(dnsNameTag))
+			{
+				names.Add(sequence.ReadCharacterString(UniversalTagNumber.IA5String, dnsNameTag));
+				continue;
+			}
+
+			sequence.ReadEncodedValue();
+		}
+
+		return names;
+	}
+}

--- a/src/BrowserPicker.UI/ViewModels/ApplicationViewModel.cs
+++ b/src/BrowserPicker.UI/ViewModels/ApplicationViewModel.cs
@@ -377,6 +377,35 @@ public sealed class ApplicationViewModel : ModelBase
 	public ICommand Edit => new DelegateCommand(OpenURLEditor);
 
 	/// <summary>
+	/// Runs an explicit TLS/certificate check for the current HTTPS URL.
+	/// </summary>
+	public ICommand CheckConnection =>
+		check_connection ??= new DelegateCommand(OpenConnectionCheckWindow, CanCheckConnection);
+
+	public ConnectionCheckIndicatorState ConnectionCheckState
+	{
+		get => connection_check_state;
+		private set
+		{
+			if (SetProperty(ref connection_check_state, value))
+			{
+				OnPropertyChanged(nameof(ConnectionCheckToolTip));
+			}
+		}
+	}
+
+	public string ConnectionCheckToolTip =>
+		ConnectionCheckState switch
+		{
+			ConnectionCheckIndicatorState.Good => "Connection check passed",
+			ConnectionCheckIndicatorState.Warning => "Connection check found warnings",
+			ConnectionCheckIndicatorState.Error => "Connection check found problems",
+			ConnectionCheckIndicatorState.Unresolved => "Connection check could not resolve the host",
+			_ =>
+				"Check the TLS certificate. This contacts the target host and may be visible to the website or proxies.",
+		};
+
+	/// <summary>
 	/// Gets the view model responsible for managing application configuration settings.
 	/// Provides access to user preferences and saved browser configurations.
 	/// </summary>
@@ -498,6 +527,48 @@ public sealed class ApplicationViewModel : ModelBase
 		if (editor.ShowDialog() == true)
 		{
 			Url.UnderlyingTargetURL = editor.EditedUrl;
+			ConnectionCheckState = ConnectionCheckIndicatorState.NotScanned;
+			check_connection?.RaiseCanExecuteChanged();
+		}
+	}
+
+	private bool CanCheckConnection()
+	{
+		return !Configuration.Settings.HideManualConnectionCheck
+			&& !string.IsNullOrWhiteSpace(Url.UnderlyingTargetURL ?? Url.TargetURL);
+	}
+
+	private void OpenConnectionCheckWindow()
+	{
+		ConnectionCheckViewModel viewModel;
+		if (Configuration.Settings.DisableNetworkAccess)
+		{
+			viewModel = new ConnectionCheckViewModel("Network checks are disabled in settings.");
+		}
+		else if (
+			!TlsCertificateSummary.TryCreateTarget(
+				Url.UnderlyingTargetURL ?? Url.TargetURL,
+				out var uri,
+				out var errorMessage
+			)
+		)
+		{
+			viewModel = new ConnectionCheckViewModel(errorMessage);
+		}
+		else
+		{
+			viewModel = new ConnectionCheckViewModel(
+				uri,
+				Configuration.Settings.CheckCertificateRecords,
+				Configuration.Settings.SkipConnectionCheckConfirmation
+			);
+		}
+
+		var window = new ConnectionCheckWindow(viewModel) { Owner = Application.Current?.MainWindow };
+		window.ShowDialog();
+		if (viewModel.ResultState != ConnectionCheckIndicatorState.NotScanned)
+		{
+			ConnectionCheckState = viewModel.ResultState;
 		}
 	}
 
@@ -655,6 +726,11 @@ public sealed class ApplicationViewModel : ModelBase
 		{
 			RebuildPickerChoices();
 		}
+
+		if (e.PropertyName == nameof(IApplicationSettings.HideManualConnectionCheck))
+		{
+			check_connection?.RaiseCanExecuteChanged();
+		}
 	}
 
 	private async void RefreshCurrentUrlFavicon()
@@ -675,4 +751,6 @@ public sealed class ApplicationViewModel : ModelBase
 	private readonly bool force_choice;
 	private bool pinned;
 	private bool copied;
+	private ConnectionCheckIndicatorState connection_check_state;
+	private DelegateCommand? check_connection;
 }

--- a/src/BrowserPicker.UI/ViewModels/ConfigurationViewModel.cs
+++ b/src/BrowserPicker.UI/ViewModels/ConfigurationViewModel.cs
@@ -144,6 +144,9 @@ public sealed class ConfigurationViewModel : ModelBase
 		public bool RedirectsKnownOnly { get; set; } = true;
 		public bool ProbeFavicons { get; set; } = true;
 		public bool FaviconsForDefaults { get; set; } = true;
+		public bool CheckCertificateRecords { get; set; } = true;
+		public bool HideManualConnectionCheck { get; set; }
+		public bool SkipConnectionCheckConfirmation { get; set; }
 
 		public bool AutoSizeWindow { get; set; } = true;
 		public double WindowWidth { get; set; }
@@ -794,6 +797,9 @@ public sealed class ConfigurationViewModel : ModelBase
 			case nameof(IApplicationSettings.RedirectsKnownOnly):
 			case nameof(IApplicationSettings.ProbeFavicons):
 			case nameof(IApplicationSettings.FaviconsForDefaults):
+			case nameof(IApplicationSettings.CheckCertificateRecords):
+			case nameof(IApplicationSettings.HideManualConnectionCheck):
+			case nameof(IApplicationSettings.SkipConnectionCheckConfirmation):
 				OnPropertyChanged(nameof(SelectedSecurityProfile));
 				apply_security_profile?.RaiseCanExecuteChanged();
 				break;

--- a/src/BrowserPicker.UI/ViewModels/ConnectionCheckViewModel.cs
+++ b/src/BrowserPicker.UI/ViewModels/ConnectionCheckViewModel.cs
@@ -1,0 +1,393 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Net.Sockets;
+using System.Security.Authentication;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using BrowserPicker.Common;
+using BrowserPicker.Common.Framework;
+
+namespace BrowserPicker.UI.ViewModels;
+
+public enum ConnectionCheckIndicatorState
+{
+	NotScanned,
+	Good,
+	Warning,
+	Error,
+	Unresolved,
+}
+
+public sealed class ConnectionCheckViewModel : ModelBase
+{
+	private readonly Uri? uri;
+	private readonly bool include_certificate_records;
+	private readonly bool skip_confirmation;
+	private CancellationTokenSource? cancellation;
+	private string status = "Ready";
+	private string? reportText;
+	private ConnectionCheckIndicatorState result_state;
+	private bool has_summary;
+	private bool is_running;
+	private bool has_started;
+	private bool can_start;
+
+#if DEBUG
+	public ConnectionCheckViewModel()
+		: this(
+			new Uri("https://github.com/mortenn/BrowserPicker"),
+			includeCertificateRecords: true,
+			skipConfirmation: false
+		) { }
+#endif
+
+	public ConnectionCheckViewModel(Uri uri, bool includeCertificateRecords, bool skipConfirmation)
+	{
+		this.uri = uri;
+		include_certificate_records = includeCertificateRecords;
+		skip_confirmation = skipConfirmation;
+		can_start = true;
+		ConfirmText = includeCertificateRecords
+			? $"Checking the TLS certificate will contact the target host ({uri.Host}) and may query DNS for CAA records. The website, DNS resolver, and network proxies may see this activity."
+			: $"Checking the TLS certificate will contact only the target host ({uri.Host}). The website and network proxies may see this connection.";
+	}
+
+	public ConnectionCheckViewModel(string unavailableReason)
+	{
+		ConfirmText = unavailableReason;
+		Status = "Cannot check this connection";
+		ReportText = unavailableReason;
+		HasStarted = true;
+		can_start = false;
+	}
+
+	public event EventHandler? CloseRequested;
+
+	public string ConfirmText { get; }
+
+	public bool SkipConfirmation => skip_confirmation;
+
+	public ConnectionCheckIndicatorState ResultState
+	{
+		get => result_state;
+		private set => SetProperty(ref result_state, value);
+	}
+
+	public ObservableCollection<ConnectionCheckDetailViewModel> Details { get; } = [];
+
+	public ObservableCollection<ConnectionCheckSectionViewModel> Sections { get; } = [];
+
+	public ConnectionCheckSectionViewModel? OverviewSection =>
+		Sections.FirstOrDefault(section => section.Title == "Overview");
+
+	public IEnumerable<ConnectionCheckSectionViewModel> CollapsibleSections =>
+		Sections.Where(section => section.Title != "Overview");
+
+	public string Status
+	{
+		get => status;
+		private set => SetProperty(ref status, value);
+	}
+
+	public string? ReportText
+	{
+		get => reportText;
+		private set
+		{
+			if (SetProperty(ref reportText, value))
+			{
+				OnPropertyChanged(nameof(HasReportText));
+			}
+		}
+	}
+
+	public bool HasReportText => !string.IsNullOrWhiteSpace(ReportText);
+
+	public bool HasSummary
+	{
+		get => has_summary;
+		private set
+		{
+			if (SetProperty(ref has_summary, value))
+			{
+				OnPropertyChanged(nameof(OverviewSection));
+				OnPropertyChanged(nameof(CollapsibleSections));
+			}
+		}
+	}
+
+	public bool IsRunning
+	{
+		get => is_running;
+		private set
+		{
+			if (SetProperty(ref is_running, value))
+			{
+				start?.RaiseCanExecuteChanged();
+				cancel?.RaiseCanExecuteChanged();
+				close?.RaiseCanExecuteChanged();
+			}
+		}
+	}
+
+	public bool HasStarted
+	{
+		get => has_started;
+		private set
+		{
+			if (SetProperty(ref has_started, value))
+			{
+				start?.RaiseCanExecuteChanged();
+			}
+		}
+	}
+
+	public ICommand Start => start ??= new DelegateCommand(() => _ = StartAsync(), () => can_start && !HasStarted);
+
+	public ICommand Cancel => cancel ??= new DelegateCommand(CancelCheck, () => IsRunning);
+
+	public ICommand Close => close ??= new DelegateCommand(RequestClose, () => !IsRunning);
+
+	public void StartIfRequested()
+	{
+		if (SkipConfirmation)
+		{
+			_ = StartAsync();
+		}
+	}
+
+	private async Task StartAsync()
+	{
+		if (uri == null || IsRunning)
+		{
+			return;
+		}
+
+		HasStarted = true;
+		IsRunning = true;
+		Status = "Checking connection...";
+		ReportText = null;
+		HasSummary = false;
+		Details.Clear();
+		Sections.Clear();
+		cancellation = new CancellationTokenSource();
+
+		try
+		{
+			var summary = await TlsCertificateSummary.InspectAsync(
+				uri,
+				include_certificate_records,
+				cancellation.Token
+			);
+			Status = "Connection check complete";
+			SetSummary(summary);
+		}
+		catch (OperationCanceledException)
+		{
+			Status = "Connection check canceled";
+			ReportText = "The connection check was canceled or timed out.";
+			ResultState = ConnectionCheckIndicatorState.NotScanned;
+		}
+		catch (SocketException ex)
+		{
+			Status = "Connection check failed";
+			ReportText = $"The connection check failed: {ex.Message}";
+			ResultState = IsDnsResolutionFailure(ex)
+				? ConnectionCheckIndicatorState.Unresolved
+				: ConnectionCheckIndicatorState.Error;
+		}
+		catch (Exception ex) when (ex is AuthenticationException or IOException or InvalidOperationException)
+		{
+			Status = "Connection check failed";
+			ReportText = $"The connection check failed: {ex.Message}";
+			ResultState = ConnectionCheckIndicatorState.Error;
+		}
+		finally
+		{
+			cancellation?.Dispose();
+			cancellation = null;
+			IsRunning = false;
+		}
+	}
+
+	private void CancelCheck()
+	{
+		cancellation?.Cancel();
+	}
+
+	private void RequestClose()
+	{
+		CloseRequested?.Invoke(this, EventArgs.Empty);
+	}
+
+	private void SetSummary(TlsCertificateSummary summary)
+	{
+		Details.Clear();
+		Sections.Clear();
+		AddSection(
+			"Overview",
+			string.Empty,
+			[
+				new ConnectionCheckDetailViewModel("Target", summary.Uri.ToString()),
+				new ConnectionCheckDetailViewModel("Validation", summary.ValidationText),
+				new ConnectionCheckDetailViewModel("Host match", summary.HostMatchText),
+				new ConnectionCheckDetailViewModel("Chain", summary.ChainText),
+			]
+		);
+		AddSection(
+			"Certificate",
+			FormatCertificateSummary(summary),
+			[
+				new ConnectionCheckDetailViewModel("Issuer", summary.Issuer),
+				new ConnectionCheckDetailViewModel("Subject", summary.Subject),
+				new ConnectionCheckDetailViewModel("Common name", summary.CommonName),
+				new ConnectionCheckDetailViewModel("SAN DNS names", summary.SubjectAlternativeNamesText),
+				new ConnectionCheckDetailViewModel("Valid from", summary.ValidFromText),
+				new ConnectionCheckDetailViewModel("Expires", summary.ExpiresText),
+			]
+		);
+		AddSection(
+			"Encryption",
+			FormatCipherSummary(summary.CipherStrengthText),
+			[
+				new ConnectionCheckDetailViewModel("Protocol", summary.ProtocolText),
+				new ConnectionCheckDetailViewModel("Cipher strength", summary.CipherStrengthText),
+				new ConnectionCheckDetailViewModel("Cipher suite", summary.CipherSuiteText),
+			]
+		);
+		AddSection(
+			"Transparency",
+			FormatRecordsSummary(summary.CertificateAuthorityAuthorizationText, summary.CertificateTransparencyText),
+			[
+				new ConnectionCheckDetailViewModel("CAA", summary.CertificateAuthorityAuthorizationText),
+				new ConnectionCheckDetailViewModel("Certificate transparency", summary.CertificateTransparencyText),
+			]
+		);
+		ReportText = null;
+		ResultState = ClassifySummary(summary);
+		HasSummary = true;
+	}
+
+	private void AddSection(string title, string summary, IEnumerable<ConnectionCheckDetailViewModel> details)
+	{
+		var rows = details.Where(detail => !string.IsNullOrWhiteSpace(detail.Value)).ToArray();
+		if (rows.Length > 0)
+		{
+			Sections.Add(new ConnectionCheckSectionViewModel(title, summary, rows));
+			foreach (var row in rows)
+			{
+				Details.Add(row);
+			}
+		}
+	}
+
+	private static string FormatCertificateSummary(TlsCertificateSummary summary)
+	{
+		var now = DateTimeOffset.Now;
+		if (summary.ValidFrom > now)
+		{
+			return "Not valid yet";
+		}
+
+		return summary.Expires <= now.AddDays(30) ? "Expiring" : "Valid";
+	}
+
+	private static string FormatCipherSummary(string? cipherStrength)
+	{
+		if (string.IsNullOrWhiteSpace(cipherStrength))
+		{
+			return "Unknown";
+		}
+
+		var end = cipherStrength.IndexOfAny(['.', '(']);
+		return end > 0 ? cipherStrength[..end].Trim() : cipherStrength;
+	}
+
+	private static string FormatRecordsSummary(string caa, string ct)
+	{
+		if (caa == "Aligned" && ct.StartsWith("Looks normal", StringComparison.OrdinalIgnoreCase))
+		{
+			return "Aligned";
+		}
+
+		if (caa == "Not checked" || ct == "Not checked")
+		{
+			return "Not checked";
+		}
+
+		return caa == "None" ? "No CAA" : "Review";
+	}
+
+	private static ConnectionCheckIndicatorState ClassifySummary(TlsCertificateSummary summary)
+	{
+		if (
+			summary.PolicyErrors != System.Net.Security.SslPolicyErrors.None
+			|| !summary.HostNameMatchesCertificate
+			|| summary.ChainStatus.Count > 0
+			|| IsBadCipher(summary.CipherStrengthText)
+			|| summary.CertificateAuthorityAuthorizationText == "Unaligned"
+		)
+		{
+			return ConnectionCheckIndicatorState.Error;
+		}
+
+		if (
+			FormatCertificateSummary(summary) != "Valid"
+			|| IsIncompleteTransparency(
+				summary.CertificateAuthorityAuthorizationText,
+				summary.CertificateTransparencyText
+			)
+			|| IsUnknownCipher(summary.CipherStrengthText)
+		)
+		{
+			return ConnectionCheckIndicatorState.Warning;
+		}
+
+		return ConnectionCheckIndicatorState.Good;
+	}
+
+	private static bool IsBadCipher(string? cipherStrength)
+	{
+		return StartsWithAny(cipherStrength, "Insecure", "Weak");
+	}
+
+	private static bool IsUnknownCipher(string? cipherStrength)
+	{
+		return StartsWithAny(cipherStrength, "Unknown", "Not post-quantum");
+	}
+
+	private static bool IsIncompleteTransparency(string caa, string ct)
+	{
+		return caa is "None" or "Not checked"
+			|| ct == "Not checked"
+			|| ct.StartsWith("No embedded", StringComparison.OrdinalIgnoreCase)
+			|| ct.StartsWith("Inconclusive", StringComparison.OrdinalIgnoreCase);
+	}
+
+	private static bool StartsWithAny(string? value, params string[] prefixes)
+	{
+		return !string.IsNullOrWhiteSpace(value)
+			&& prefixes.Any(prefix => value.StartsWith(prefix, StringComparison.OrdinalIgnoreCase));
+	}
+
+	private static bool IsDnsResolutionFailure(SocketException ex)
+	{
+		return ex.SocketErrorCode is SocketError.HostNotFound or SocketError.NoData or SocketError.TryAgain;
+	}
+
+	private DelegateCommand? start;
+	private DelegateCommand? cancel;
+	private DelegateCommand? close;
+}
+
+public sealed record ConnectionCheckDetailViewModel(string Label, string? Value);
+
+public sealed record ConnectionCheckSectionViewModel(
+	string Title,
+	string Summary,
+	IReadOnlyList<ConnectionCheckDetailViewModel> Details
+);

--- a/src/BrowserPicker.UI/ViewModels/FeedbackViewModel.cs
+++ b/src/BrowserPicker.UI/ViewModels/FeedbackViewModel.cs
@@ -595,6 +595,9 @@ public sealed class FeedbackViewModel : ModelBase
 		public bool RedirectsKnownOnly { get; set; } = true;
 		public bool ProbeFavicons { get; set; } = true;
 		public bool FaviconsForDefaults { get; set; } = true;
+		public bool CheckCertificateRecords { get; set; } = true;
+		public bool HideManualConnectionCheck { get; set; }
+		public bool SkipConnectionCheckConfirmation { get; set; }
 		public string[] UrlShorteners { get; set; } = [.. UrlHandler.DefaultUrlShorteners, "example.com"];
 		public List<BrowserModel> BrowserList { get; } =
 		[

--- a/src/BrowserPicker.UI/Views/BrowserList.xaml
+++ b/src/BrowserPicker.UI/Views/BrowserList.xaml
@@ -1,4 +1,4 @@
-<UserControl
+﻿<UserControl
 	x:Class="BrowserPicker.UI.Views.BrowserList"
 	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -75,10 +75,7 @@
 					<Hyperlink Command="{Binding Edit}" Foreground="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}" TextDecorations="None" ToolTip="Edit the URL before opening it">
 						✏
 					</Hyperlink>
-					<Hyperlink
-						Command="{Binding CheckConnection}"
-						TextDecorations="None"
-						ToolTip="{Binding ConnectionCheckToolTip}">
+					<Hyperlink Command="{Binding CheckConnection}" TextDecorations="None" ToolTip="{Binding ConnectionCheckToolTip}">
 						<Hyperlink.Style>
 							<Style TargetType="{x:Type Hyperlink}">
 								<Setter Property="Foreground" Value="{DynamicResource {x:Static ui:App.ContentForegroundBrushKey}}" />
@@ -96,11 +93,7 @@
 							</Style>
 						</Hyperlink.Style>
 						<InlineUIContainer BaselineAlignment="Center">
-							<TextBlock
-								Margin="0,1,0,0"
-								FontFamily="Segoe MDL2 Assets"
-								FontSize="14"
-								Text="&#xE72E;">
+							<TextBlock Margin="0,1,0,0" FontFamily="Segoe MDL2 Assets" FontSize="14" Text="&#xE72E;">
 								<TextBlock.Style>
 									<Style TargetType="{x:Type TextBlock}">
 										<Setter Property="Visibility" Value="Visible" />

--- a/src/BrowserPicker.UI/Views/BrowserList.xaml
+++ b/src/BrowserPicker.UI/Views/BrowserList.xaml
@@ -75,6 +75,45 @@
 					<Hyperlink Command="{Binding Edit}" Foreground="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}" TextDecorations="None" ToolTip="Edit the URL before opening it">
 						✏
 					</Hyperlink>
+					<Hyperlink
+						Command="{Binding CheckConnection}"
+						TextDecorations="None"
+						ToolTip="{Binding ConnectionCheckToolTip}">
+						<Hyperlink.Style>
+							<Style TargetType="{x:Type Hyperlink}">
+								<Setter Property="Foreground" Value="{DynamicResource {x:Static ui:App.ContentForegroundBrushKey}}" />
+								<Style.Triggers>
+									<DataTrigger Binding="{Binding ConnectionCheckState}" Value="{x:Static viewModels:ConnectionCheckIndicatorState.Good}">
+										<Setter Property="Foreground" Value="#4CAF50" />
+									</DataTrigger>
+									<DataTrigger Binding="{Binding ConnectionCheckState}" Value="{x:Static viewModels:ConnectionCheckIndicatorState.Warning}">
+										<Setter Property="Foreground" Value="#FFC107" />
+									</DataTrigger>
+									<DataTrigger Binding="{Binding ConnectionCheckState}" Value="{x:Static viewModels:ConnectionCheckIndicatorState.Error}">
+										<Setter Property="Foreground" Value="#F44336" />
+									</DataTrigger>
+								</Style.Triggers>
+							</Style>
+						</Hyperlink.Style>
+						<InlineUIContainer BaselineAlignment="Center">
+							<TextBlock
+								Margin="0,1,0,0"
+								FontFamily="Segoe MDL2 Assets"
+								FontSize="14"
+								Text="&#xE72E;">
+								<TextBlock.Style>
+									<Style TargetType="{x:Type TextBlock}">
+										<Setter Property="Visibility" Value="Visible" />
+										<Style.Triggers>
+											<DataTrigger Binding="{Binding Configuration.Settings.HideManualConnectionCheck}" Value="True">
+												<Setter Property="Visibility" Value="Collapsed" />
+											</DataTrigger>
+										</Style.Triggers>
+									</Style>
+								</TextBlock.Style>
+							</TextBlock>
+						</InlineUIContainer>
+					</Hyperlink>
 				</TextBlock>
 				<TextBlock Margin="5,5,0,0" Foreground="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}" Text="Redirected URL">
 					<TextBlock.Style>

--- a/src/BrowserPicker.UI/Views/Configuration.xaml
+++ b/src/BrowserPicker.UI/Views/Configuration.xaml
@@ -1,4 +1,4 @@
-<UserControl
+﻿<UserControl
 	x:Class="BrowserPicker.UI.Views.Configuration"
 	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -479,14 +479,8 @@
 							</Style>
 						</Grid.Resources>
 						<StackPanel>
-							<Menu
-								Margin="0,4,0,10"
-								Background="Transparent"
-								Foreground="{DynamicResource {x:Static ui:App.ContentForegroundBrushKey}}">
-								<MenuItem
-									Header="Apply profile"
-									Foreground="{DynamicResource {x:Static ui:App.ContentForegroundBrushKey}}"
-									ItemsSource="{x:Static securityProfiles:PredefinedSecurityProfiles.All}">
+							<Menu Margin="0,4,0,10" Background="Transparent" Foreground="{DynamicResource {x:Static ui:App.ContentForegroundBrushKey}}">
+								<MenuItem Foreground="{DynamicResource {x:Static ui:App.ContentForegroundBrushKey}}" Header="Apply profile" ItemsSource="{x:Static securityProfiles:PredefinedSecurityProfiles.All}">
 									<MenuItem.ItemContainerStyle>
 										<Style TargetType="{x:Type MenuItem}">
 											<Setter Property="Header" Value="{Binding DisplayName}" />
@@ -539,18 +533,9 @@
 							</StackPanel>
 
 							<TextBlock Margin="0,8,0,6" FontWeight="Bold" Text="Manual probes" />
-							<CheckBox
-								Content="Include DNS CAA and certificate transparency evidence"
-								IsChecked="{Binding Settings.CheckCertificateRecords}"
-								ToolTip="Used only when you click Check connection. CAA requires a DNS lookup; CT checks embedded certificate transparency evidence." />
-							<CheckBox
-								Content="Hide connection check button"
-								IsChecked="{Binding Settings.HideManualConnectionCheck}"
-								ToolTip="Removes the padlock connection check action from the picker." />
-							<CheckBox
-								Content="Skip confirmation prompt"
-								IsChecked="{Binding Settings.SkipConnectionCheckConfirmation}"
-								ToolTip="Starts the connection check immediately when you click the padlock." />
+							<CheckBox Content="Include DNS CAA and certificate transparency evidence" IsChecked="{Binding Settings.CheckCertificateRecords}" ToolTip="Used only when you click Check connection. CAA requires a DNS lookup; CT checks embedded certificate transparency evidence." />
+							<CheckBox Content="Hide connection check button" IsChecked="{Binding Settings.HideManualConnectionCheck}" ToolTip="Removes the padlock connection check action from the picker." />
+							<CheckBox Content="Skip confirmation prompt" IsChecked="{Binding Settings.SkipConnectionCheckConfirmation}" ToolTip="Starts the connection check immediately when you click the padlock." />
 						</StackPanel>
 					</Grid>
 				</ScrollViewer>

--- a/src/BrowserPicker.UI/Views/Configuration.xaml
+++ b/src/BrowserPicker.UI/Views/Configuration.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl
+<UserControl
 	x:Class="BrowserPicker.UI.Views.Configuration"
 	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -479,12 +479,18 @@
 							</Style>
 						</Grid.Resources>
 						<StackPanel>
-							<TextBlock Margin="0,4,0,6" FontWeight="Bold" Text="Automatic probes" />
-							<Menu Margin="0,0,0,10" Background="Transparent">
-								<MenuItem Header="Apply profile" ItemsSource="{x:Static securityProfiles:PredefinedSecurityProfiles.All}">
+							<Menu
+								Margin="0,4,0,10"
+								Background="Transparent"
+								Foreground="{DynamicResource {x:Static ui:App.ContentForegroundBrushKey}}">
+								<MenuItem
+									Header="Apply profile"
+									Foreground="{DynamicResource {x:Static ui:App.ContentForegroundBrushKey}}"
+									ItemsSource="{x:Static securityProfiles:PredefinedSecurityProfiles.All}">
 									<MenuItem.ItemContainerStyle>
 										<Style TargetType="{x:Type MenuItem}">
 											<Setter Property="Header" Value="{Binding DisplayName}" />
+											<Setter Property="Foreground" Value="{DynamicResource {x:Static ui:App.ContentForegroundBrushKey}}" />
 											<Setter Property="IsCheckable" Value="True" />
 											<Setter Property="Command" Value="{Binding DataContext.ApplySecurityProfile, RelativeSource={RelativeSource AncestorType={x:Type UserControl}}}" />
 											<Setter Property="CommandParameter" Value="{Binding}" />
@@ -501,6 +507,7 @@
 								</MenuItem>
 							</Menu>
 
+							<TextBlock Margin="0,4,0,6" FontWeight="Bold" Text="Automatic probes" />
 							<CheckBox Content="Probe URL shorteners / redirects" IsChecked="{Binding Settings.ProbeRedirects}" />
 							<StackPanel Margin="20,0,0,8">
 								<StackPanel.Style>
@@ -530,6 +537,20 @@
 								</StackPanel.Style>
 								<CheckBox Content="Only for URLs matching defaults" IsChecked="{Binding Settings.FaviconsForDefaults}" />
 							</StackPanel>
+
+							<TextBlock Margin="0,8,0,6" FontWeight="Bold" Text="Manual probes" />
+							<CheckBox
+								Content="Include DNS CAA and certificate transparency evidence"
+								IsChecked="{Binding Settings.CheckCertificateRecords}"
+								ToolTip="Used only when you click Check connection. CAA requires a DNS lookup; CT checks embedded certificate transparency evidence." />
+							<CheckBox
+								Content="Hide connection check button"
+								IsChecked="{Binding Settings.HideManualConnectionCheck}"
+								ToolTip="Removes the padlock connection check action from the picker." />
+							<CheckBox
+								Content="Skip confirmation prompt"
+								IsChecked="{Binding Settings.SkipConnectionCheckConfirmation}"
+								ToolTip="Starts the connection check immediately when you click the padlock." />
 						</StackPanel>
 					</Grid>
 				</ScrollViewer>

--- a/src/BrowserPicker.UI/Views/ConnectionCheckWindow.xaml
+++ b/src/BrowserPicker.UI/Views/ConnectionCheckWindow.xaml
@@ -1,0 +1,283 @@
+<Window
+	x:Class="BrowserPicker.UI.Views.ConnectionCheckWindow"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:ui="clr-namespace:BrowserPicker.UI"
+	xmlns:viewModels="clr-namespace:BrowserPicker.UI.ViewModels"
+	Title="Check connection"
+	Width="760"
+	Height="520"
+	MinWidth="560"
+	MinHeight="360"
+	Background="{DynamicResource {x:Static ui:App.ContentBackgroundBrushKey}}"
+	Foreground="{DynamicResource {x:Static ui:App.ContentForegroundBrushKey}}"
+	ShowInTaskbar="False"
+	WindowStartupLocation="CenterOwner"
+	d:DataContext="{d:DesignInstance viewModels:ConnectionCheckViewModel,
+									 d:IsDesignTimeCreatable=True}"
+	mc:Ignorable="d">
+	<Window.Resources>
+		<Style x:Key="DialogButtonStyle" TargetType="{x:Type Button}">
+			<Setter Property="MinWidth" Value="96" />
+			<Setter Property="Padding" Value="12,5" />
+			<Setter Property="Foreground" Value="{DynamicResource {x:Static ui:App.ContentForegroundBrushKey}}" />
+			<Setter Property="Background" Value="#3A3A3A" />
+			<Setter Property="BorderBrush" Value="#666666" />
+			<Setter Property="BorderThickness" Value="1" />
+			<Setter Property="Cursor" Value="Hand" />
+			<Setter Property="Template">
+				<Setter.Value>
+					<ControlTemplate TargetType="{x:Type Button}">
+						<Border
+							x:Name="Chrome"
+							Padding="{TemplateBinding Padding}"
+							Background="{TemplateBinding Background}"
+							BorderBrush="{TemplateBinding BorderBrush}"
+							BorderThickness="{TemplateBinding BorderThickness}"
+							CornerRadius="4">
+							<ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" />
+						</Border>
+						<ControlTemplate.Triggers>
+							<Trigger Property="IsMouseOver" Value="True">
+								<Setter TargetName="Chrome" Property="Background" Value="#484848" />
+								<Setter TargetName="Chrome" Property="BorderBrush" Value="#888888" />
+							</Trigger>
+							<Trigger Property="IsPressed" Value="True">
+								<Setter TargetName="Chrome" Property="Background" Value="#2F2F2F" />
+							</Trigger>
+							<Trigger Property="IsEnabled" Value="False">
+								<Setter TargetName="Chrome" Property="Opacity" Value="0.45" />
+							</Trigger>
+						</ControlTemplate.Triggers>
+					</ControlTemplate>
+				</Setter.Value>
+			</Setter>
+		</Style>
+		<Style x:Key="PrimaryDialogButtonStyle" BasedOn="{StaticResource DialogButtonStyle}" TargetType="{x:Type Button}">
+			<Setter Property="Background" Value="#333333" />
+			<Setter Property="BorderBrush" Value="#2B88D8" />
+		</Style>
+		<Style x:Key="DetailLabelStyle" TargetType="{x:Type TextBlock}">
+			<Setter Property="Margin" Value="0,0,12,7" />
+			<Setter Property="FontWeight" Value="SemiBold" />
+			<Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}" />
+		</Style>
+		<Style x:Key="DetailValueStyle" TargetType="{x:Type TextBlock}">
+			<Setter Property="Margin" Value="0,0,0,7" />
+			<Setter Property="TextWrapping" Value="Wrap" />
+		</Style>
+	</Window.Resources>
+	<Grid Margin="12">
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="*" />
+			<RowDefinition Height="Auto" />
+		</Grid.RowDefinitions>
+
+		<TextBlock FontSize="16" FontWeight="SemiBold" Text="{Binding Status, Mode=OneWay}">
+			<TextBlock.Style>
+				<Style TargetType="{x:Type TextBlock}">
+					<Setter Property="Visibility" Value="Visible" />
+					<Style.Triggers>
+						<DataTrigger Binding="{Binding HasSummary}" Value="True">
+							<Setter Property="Visibility" Value="Collapsed" />
+						</DataTrigger>
+					</Style.Triggers>
+				</Style>
+			</TextBlock.Style>
+		</TextBlock>
+		<Border
+			Grid.Row="1"
+			Margin="0,10,0,14"
+			Padding="12"
+			Background="#242424"
+			BorderBrush="#454545"
+			BorderThickness="1"
+			CornerRadius="6">
+			<Border.Style>
+				<Style TargetType="{x:Type Border}">
+					<Setter Property="Visibility" Value="Visible" />
+					<Style.Triggers>
+						<DataTrigger Binding="{Binding HasSummary}" Value="True">
+							<Setter Property="Visibility" Value="Collapsed" />
+						</DataTrigger>
+					</Style.Triggers>
+				</Style>
+			</Border.Style>
+			<Grid>
+				<Grid.ColumnDefinitions>
+					<ColumnDefinition Width="*" />
+					<ColumnDefinition Width="Auto" />
+				</Grid.ColumnDefinitions>
+				<StackPanel>
+					<StackPanel.Style>
+						<Style TargetType="{x:Type StackPanel}">
+							<Setter Property="Visibility" Value="Visible" />
+							<Style.Triggers>
+								<DataTrigger Binding="{Binding SkipConfirmation}" Value="True">
+									<Setter Property="Visibility" Value="Collapsed" />
+								</DataTrigger>
+							</Style.Triggers>
+						</Style>
+					</StackPanel.Style>
+					<TextBlock FontWeight="SemiBold" Text="Before you start" />
+					<TextBlock
+						Margin="0,4,16,0"
+						Opacity="0.9"
+						Text="{Binding ConfirmText, Mode=OneWay}"
+						TextWrapping="Wrap" />
+				</StackPanel>
+				<StackPanel Grid.Column="1" VerticalAlignment="Center" Orientation="Horizontal">
+					<Button
+						Command="{Binding Cancel}"
+						Content="Cancel check">
+						<Button.Style>
+							<Style BasedOn="{StaticResource DialogButtonStyle}" TargetType="{x:Type Button}">
+								<Setter Property="Visibility" Value="Collapsed" />
+								<Style.Triggers>
+									<DataTrigger Binding="{Binding IsRunning}" Value="True">
+										<Setter Property="Visibility" Value="Visible" />
+									</DataTrigger>
+								</Style.Triggers>
+							</Style>
+						</Button.Style>
+					</Button>
+					<Button
+						Margin="8,0,0,0"
+						Command="{Binding Start}"
+						Content="Check connection">
+						<Button.Style>
+							<Style BasedOn="{StaticResource PrimaryDialogButtonStyle}" TargetType="{x:Type Button}">
+								<Setter Property="Visibility" Value="Visible" />
+								<Style.Triggers>
+									<DataTrigger Binding="{Binding HasStarted}" Value="True">
+										<Setter Property="Visibility" Value="Collapsed" />
+									</DataTrigger>
+								</Style.Triggers>
+							</Style>
+						</Button.Style>
+					</Button>
+				</StackPanel>
+			</Grid>
+		</Border>
+
+		<Grid Grid.Row="2">
+			<ScrollViewer VerticalScrollBarVisibility="Auto">
+				<ScrollViewer.Style>
+					<Style TargetType="{x:Type ScrollViewer}">
+						<Setter Property="Visibility" Value="Collapsed" />
+						<Style.Triggers>
+							<DataTrigger Binding="{Binding HasSummary}" Value="True">
+								<Setter Property="Visibility" Value="Visible" />
+							</DataTrigger>
+						</Style.Triggers>
+					</Style>
+				</ScrollViewer.Style>
+				<StackPanel>
+					<Border
+						Margin="0,0,0,8"
+						Padding="12,10"
+						Background="#242424"
+						BorderBrush="#3F3F3F"
+						BorderThickness="1"
+						CornerRadius="6"
+						DataContext="{Binding OverviewSection}">
+						<StackPanel>
+							<TextBlock Margin="0,0,0,8" FontSize="14" FontWeight="SemiBold" Text="{Binding Title}" />
+							<ItemsControl ItemsSource="{Binding Details}">
+								<ItemsControl.ItemTemplate>
+									<DataTemplate DataType="{x:Type viewModels:ConnectionCheckDetailViewModel}">
+										<Grid>
+											<Grid.ColumnDefinitions>
+												<ColumnDefinition Width="155" />
+												<ColumnDefinition Width="*" />
+											</Grid.ColumnDefinitions>
+											<TextBlock Style="{StaticResource DetailLabelStyle}" Text="{Binding Label}" />
+											<TextBlock Grid.Column="1" Style="{StaticResource DetailValueStyle}" Text="{Binding Value}" />
+										</Grid>
+									</DataTemplate>
+								</ItemsControl.ItemTemplate>
+							</ItemsControl>
+						</StackPanel>
+					</Border>
+				<ItemsControl ItemsSource="{Binding CollapsibleSections}">
+					<ItemsControl.ItemTemplate>
+						<DataTemplate DataType="{x:Type viewModels:ConnectionCheckSectionViewModel}">
+							<Expander Margin="0,0,0,8" IsExpanded="False">
+								<Expander.Header>
+									<Grid>
+										<Grid.ColumnDefinitions>
+											<ColumnDefinition Width="150" />
+											<ColumnDefinition Width="*" />
+										</Grid.ColumnDefinitions>
+										<TextBlock FontSize="14" FontWeight="SemiBold" Text="{Binding Title}" />
+										<TextBlock
+											Grid.Column="1"
+											Margin="12,0,0,0"
+											Opacity="0.85"
+											Text="{Binding Summary}"
+											TextTrimming="CharacterEllipsis" />
+									</Grid>
+								</Expander.Header>
+								<Border
+									Margin="0,8,0,0"
+									Padding="12,10"
+									Background="#242424"
+									BorderBrush="#3F3F3F"
+									BorderThickness="1"
+									CornerRadius="6">
+									<ItemsControl ItemsSource="{Binding Details}">
+										<ItemsControl.ItemTemplate>
+											<DataTemplate DataType="{x:Type viewModels:ConnectionCheckDetailViewModel}">
+												<Grid>
+													<Grid.ColumnDefinitions>
+														<ColumnDefinition Width="155" />
+														<ColumnDefinition Width="*" />
+													</Grid.ColumnDefinitions>
+													<TextBlock Style="{StaticResource DetailLabelStyle}" Text="{Binding Label}" />
+													<TextBlock Grid.Column="1" Style="{StaticResource DetailValueStyle}" Text="{Binding Value}" />
+												</Grid>
+											</DataTemplate>
+										</ItemsControl.ItemTemplate>
+									</ItemsControl>
+								</Border>
+							</Expander>
+						</DataTemplate>
+					</ItemsControl.ItemTemplate>
+				</ItemsControl>
+				</StackPanel>
+			</ScrollViewer>
+			<TextBlock Text="{Binding ReportText, Mode=OneWay}" TextWrapping="Wrap">
+				<TextBlock.Style>
+					<Style TargetType="{x:Type TextBlock}">
+						<Setter Property="Visibility" Value="Collapsed" />
+						<Style.Triggers>
+							<DataTrigger Binding="{Binding HasReportText}" Value="True">
+								<Setter Property="Visibility" Value="Visible" />
+							</DataTrigger>
+						</Style.Triggers>
+					</Style>
+				</TextBlock.Style>
+			</TextBlock>
+			<TextBlock Text="Review the privacy note, then start the check when you are ready." TextWrapping="Wrap">
+				<TextBlock.Style>
+					<Style TargetType="{x:Type TextBlock}">
+						<Setter Property="Visibility" Value="Visible" />
+						<Style.Triggers>
+							<DataTrigger Binding="{Binding HasStarted}" Value="True">
+								<Setter Property="Visibility" Value="Collapsed" />
+							</DataTrigger>
+						</Style.Triggers>
+					</Style>
+				</TextBlock.Style>
+			</TextBlock>
+		</Grid>
+
+		<StackPanel Grid.Row="3" Margin="0,12,0,0" HorizontalAlignment="Right" Orientation="Horizontal">
+			<Button Command="{Binding Close}" Content="Close" IsCancel="True" Style="{StaticResource DialogButtonStyle}" />
+		</StackPanel>
+	</Grid>
+</Window>

--- a/src/BrowserPicker.UI/Views/ConnectionCheckWindow.xaml
+++ b/src/BrowserPicker.UI/Views/ConnectionCheckWindow.xaml
@@ -1,4 +1,4 @@
-<Window
+﻿<Window
 	x:Class="BrowserPicker.UI.Views.ConnectionCheckWindow"
 	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -11,12 +11,12 @@
 	Height="520"
 	MinWidth="560"
 	MinHeight="360"
+	d:DataContext="{d:DesignInstance viewModels:ConnectionCheckViewModel,
+									 d:IsDesignTimeCreatable=True}"
 	Background="{DynamicResource {x:Static ui:App.ContentBackgroundBrushKey}}"
 	Foreground="{DynamicResource {x:Static ui:App.ContentForegroundBrushKey}}"
 	ShowInTaskbar="False"
 	WindowStartupLocation="CenterOwner"
-	d:DataContext="{d:DesignInstance viewModels:ConnectionCheckViewModel,
-									 d:IsDesignTimeCreatable=True}"
 	mc:Ignorable="d">
 	<Window.Resources>
 		<Style x:Key="DialogButtonStyle" TargetType="{x:Type Button}">
@@ -124,16 +124,10 @@
 						</Style>
 					</StackPanel.Style>
 					<TextBlock FontWeight="SemiBold" Text="Before you start" />
-					<TextBlock
-						Margin="0,4,16,0"
-						Opacity="0.9"
-						Text="{Binding ConfirmText, Mode=OneWay}"
-						TextWrapping="Wrap" />
+					<TextBlock Margin="0,4,16,0" Opacity="0.9" Text="{Binding ConfirmText, Mode=OneWay}" TextWrapping="Wrap" />
 				</StackPanel>
 				<StackPanel Grid.Column="1" VerticalAlignment="Center" Orientation="Horizontal">
-					<Button
-						Command="{Binding Cancel}"
-						Content="Cancel check">
+					<Button Command="{Binding Cancel}" Content="Cancel check">
 						<Button.Style>
 							<Style BasedOn="{StaticResource DialogButtonStyle}" TargetType="{x:Type Button}">
 								<Setter Property="Visibility" Value="Collapsed" />
@@ -145,10 +139,7 @@
 							</Style>
 						</Button.Style>
 					</Button>
-					<Button
-						Margin="8,0,0,0"
-						Command="{Binding Start}"
-						Content="Check connection">
+					<Button Margin="8,0,0,0" Command="{Binding Start}" Content="Check connection">
 						<Button.Style>
 							<Style BasedOn="{StaticResource PrimaryDialogButtonStyle}" TargetType="{x:Type Button}">
 								<Setter Property="Visibility" Value="Visible" />
@@ -203,51 +194,51 @@
 							</ItemsControl>
 						</StackPanel>
 					</Border>
-				<ItemsControl ItemsSource="{Binding CollapsibleSections}">
-					<ItemsControl.ItemTemplate>
-						<DataTemplate DataType="{x:Type viewModels:ConnectionCheckSectionViewModel}">
-							<Expander Margin="0,0,0,8" IsExpanded="False">
-								<Expander.Header>
-									<Grid>
-										<Grid.ColumnDefinitions>
-											<ColumnDefinition Width="150" />
-											<ColumnDefinition Width="*" />
-										</Grid.ColumnDefinitions>
-										<TextBlock FontSize="14" FontWeight="SemiBold" Text="{Binding Title}" />
-										<TextBlock
-											Grid.Column="1"
-											Margin="12,0,0,0"
-											Opacity="0.85"
-											Text="{Binding Summary}"
-											TextTrimming="CharacterEllipsis" />
-									</Grid>
-								</Expander.Header>
-								<Border
-									Margin="0,8,0,0"
-									Padding="12,10"
-									Background="#242424"
-									BorderBrush="#3F3F3F"
-									BorderThickness="1"
-									CornerRadius="6">
-									<ItemsControl ItemsSource="{Binding Details}">
-										<ItemsControl.ItemTemplate>
-											<DataTemplate DataType="{x:Type viewModels:ConnectionCheckDetailViewModel}">
-												<Grid>
-													<Grid.ColumnDefinitions>
-														<ColumnDefinition Width="155" />
-														<ColumnDefinition Width="*" />
-													</Grid.ColumnDefinitions>
-													<TextBlock Style="{StaticResource DetailLabelStyle}" Text="{Binding Label}" />
-													<TextBlock Grid.Column="1" Style="{StaticResource DetailValueStyle}" Text="{Binding Value}" />
-												</Grid>
-											</DataTemplate>
-										</ItemsControl.ItemTemplate>
-									</ItemsControl>
-								</Border>
-							</Expander>
-						</DataTemplate>
-					</ItemsControl.ItemTemplate>
-				</ItemsControl>
+					<ItemsControl ItemsSource="{Binding CollapsibleSections}">
+						<ItemsControl.ItemTemplate>
+							<DataTemplate DataType="{x:Type viewModels:ConnectionCheckSectionViewModel}">
+								<Expander Margin="0,0,0,8" IsExpanded="False">
+									<Expander.Header>
+										<Grid>
+											<Grid.ColumnDefinitions>
+												<ColumnDefinition Width="150" />
+												<ColumnDefinition Width="*" />
+											</Grid.ColumnDefinitions>
+											<TextBlock FontSize="14" FontWeight="SemiBold" Text="{Binding Title}" />
+											<TextBlock
+												Grid.Column="1"
+												Margin="12,0,0,0"
+												Opacity="0.85"
+												Text="{Binding Summary}"
+												TextTrimming="CharacterEllipsis" />
+										</Grid>
+									</Expander.Header>
+									<Border
+										Margin="0,8,0,0"
+										Padding="12,10"
+										Background="#242424"
+										BorderBrush="#3F3F3F"
+										BorderThickness="1"
+										CornerRadius="6">
+										<ItemsControl ItemsSource="{Binding Details}">
+											<ItemsControl.ItemTemplate>
+												<DataTemplate DataType="{x:Type viewModels:ConnectionCheckDetailViewModel}">
+													<Grid>
+														<Grid.ColumnDefinitions>
+															<ColumnDefinition Width="155" />
+															<ColumnDefinition Width="*" />
+														</Grid.ColumnDefinitions>
+														<TextBlock Style="{StaticResource DetailLabelStyle}" Text="{Binding Label}" />
+														<TextBlock Grid.Column="1" Style="{StaticResource DetailValueStyle}" Text="{Binding Value}" />
+													</Grid>
+												</DataTemplate>
+											</ItemsControl.ItemTemplate>
+										</ItemsControl>
+									</Border>
+								</Expander>
+							</DataTemplate>
+						</ItemsControl.ItemTemplate>
+					</ItemsControl>
 				</StackPanel>
 			</ScrollViewer>
 			<TextBlock Text="{Binding ReportText, Mode=OneWay}" TextWrapping="Wrap">

--- a/src/BrowserPicker.UI/Views/ConnectionCheckWindow.xaml.cs
+++ b/src/BrowserPicker.UI/Views/ConnectionCheckWindow.xaml.cs
@@ -1,0 +1,49 @@
+using System;
+using BrowserPicker.UI.ViewModels;
+
+namespace BrowserPicker.UI.Views;
+
+/// <summary>
+/// Interaction logic for ConnectionCheckWindow.xaml
+/// </summary>
+public partial class ConnectionCheckWindow
+{
+#if DEBUG
+	public ConnectionCheckWindow()
+	{
+		InitializeComponent();
+	}
+#endif
+
+	public ConnectionCheckWindow(ConnectionCheckViewModel viewModel)
+	{
+		DataContext = viewModel;
+		viewModel.CloseRequested += ViewModel_CloseRequested;
+		InitializeComponent();
+		Loaded += ConnectionCheckWindow_Loaded;
+	}
+
+	protected override void OnClosed(EventArgs e)
+	{
+		if (DataContext is ConnectionCheckViewModel viewModel)
+		{
+			viewModel.CloseRequested -= ViewModel_CloseRequested;
+		}
+		Loaded -= ConnectionCheckWindow_Loaded;
+
+		base.OnClosed(e);
+	}
+
+	private void ConnectionCheckWindow_Loaded(object sender, EventArgs e)
+	{
+		if (DataContext is ConnectionCheckViewModel viewModel)
+		{
+			viewModel.StartIfRequested();
+		}
+	}
+
+	private void ViewModel_CloseRequested(object? sender, EventArgs e)
+	{
+		DialogResult = true;
+	}
+}

--- a/src/BrowserPicker.Windows/AppSettings.cs
+++ b/src/BrowserPicker.Windows/AppSettings.cs
@@ -34,6 +34,9 @@ public sealed class AppSettings : IApplicationSettings
 			RedirectsKnownOnly = true;
 			ProbeFavicons = !DisableNetworkAccess;
 			FaviconsForDefaults = true;
+			CheckCertificateRecords = true;
+			HideManualConnectionCheck = false;
+			SkipConnectionCheckConfirmation = false;
 			UrlShorteners = Reg.Get<string[]>() ?? [];
 			WindowWidth = double.TryParse(Reg.GetValue("WindowWidth") as string, out var w) ? w : 0;
 			WindowHeight = double.TryParse(Reg.GetValue("WindowHeight") as string, out var h) ? h : 0;
@@ -124,6 +127,15 @@ public sealed class AppSettings : IApplicationSettings
 
 	/// <inheritdoc />
 	public bool FaviconsForDefaults { get; set; } = true;
+
+	/// <inheritdoc />
+	public bool CheckCertificateRecords { get; set; } = true;
+
+	/// <inheritdoc />
+	public bool HideManualConnectionCheck { get; set; }
+
+	/// <inheritdoc />
+	public bool SkipConnectionCheckConfirmation { get; set; }
 
 	/// <inheritdoc />
 	public string[] UrlShorteners { get; set; } = [];

--- a/src/BrowserPicker.Windows/JsonAppSettings.cs
+++ b/src/BrowserPicker.Windows/JsonAppSettings.cs
@@ -40,6 +40,9 @@ public sealed class JsonAppSettings : ModelBase, IBrowserPickerConfiguration
 	private bool redirects_known_only = true;
 	private bool probe_favicons = true;
 	private bool favicons_for_defaults = true;
+	private bool check_certificate_records = true;
+	private bool hide_manual_connection_check;
+	private bool skip_connection_check_confirmation;
 	private bool auto_close_on_focus_lost = true;
 	private string[] url_shorteners = [];
 	private bool use_fallback_default;
@@ -305,6 +308,33 @@ public sealed class JsonAppSettings : ModelBase, IBrowserPickerConfiguration
 		set
 		{
 			if (SetProperty(ref favicons_for_defaults, value))
+				SaveToFile();
+		}
+	}
+	public bool CheckCertificateRecords
+	{
+		get => check_certificate_records;
+		set
+		{
+			if (SetProperty(ref check_certificate_records, value))
+				SaveToFile();
+		}
+	}
+	public bool HideManualConnectionCheck
+	{
+		get => hide_manual_connection_check;
+		set
+		{
+			if (SetProperty(ref hide_manual_connection_check, value))
+				SaveToFile();
+		}
+	}
+	public bool SkipConnectionCheckConfirmation
+	{
+		get => skip_connection_check_confirmation;
+		set
+		{
+			if (SetProperty(ref skip_connection_check_confirmation, value))
 				SaveToFile();
 		}
 	}
@@ -686,6 +716,9 @@ public sealed class JsonAppSettings : ModelBase, IBrowserPickerConfiguration
 		redirects_known_only = s.RedirectsKnownOnly;
 		probe_favicons = s.ProbeFavicons;
 		favicons_for_defaults = s.FaviconsForDefaults;
+		check_certificate_records = s.CheckCertificateRecords;
+		hide_manual_connection_check = s.HideManualConnectionCheck;
+		skip_connection_check_confirmation = s.SkipConnectionCheckConfirmation;
 		auto_close_on_focus_lost = s.AutoCloseOnFocusLost;
 		url_shorteners = s.UrlShorteners;
 		window_width = NormalizeMainWindowDimension(s.WindowWidth, MinWindowWidth);
@@ -714,6 +747,9 @@ public sealed class JsonAppSettings : ModelBase, IBrowserPickerConfiguration
 		OnPropertyChanged(nameof(RedirectsKnownOnly));
 		OnPropertyChanged(nameof(ProbeFavicons));
 		OnPropertyChanged(nameof(FaviconsForDefaults));
+		OnPropertyChanged(nameof(CheckCertificateRecords));
+		OnPropertyChanged(nameof(HideManualConnectionCheck));
+		OnPropertyChanged(nameof(SkipConnectionCheckConfirmation));
 		OnPropertyChanged(nameof(AutoCloseOnFocusLost));
 		OnPropertyChanged(nameof(WindowWidth));
 		OnPropertyChanged(nameof(WindowHeight));
@@ -956,6 +992,21 @@ public sealed class JsonAppSettings : ModelBase, IBrowserPickerConfiguration
 		if (!root.ContainsKey(nameof(SerializableSettings.FaviconsForDefaults)))
 		{
 			settings.FaviconsForDefaults = true;
+			upgraded = true;
+		}
+		if (!root.ContainsKey(nameof(SerializableSettings.CheckCertificateRecords)))
+		{
+			settings.CheckCertificateRecords = true;
+			upgraded = true;
+		}
+		if (!root.ContainsKey(nameof(SerializableSettings.HideManualConnectionCheck)))
+		{
+			settings.HideManualConnectionCheck = false;
+			upgraded = true;
+		}
+		if (!root.ContainsKey(nameof(SerializableSettings.SkipConnectionCheckConfirmation)))
+		{
+			settings.SkipConnectionCheckConfirmation = false;
 			upgraded = true;
 		}
 

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -4,6 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="CSharpier.MsBuild" Version="1.2.6" />
+    <PackageVersion Include="DnsClient" Version="1.8.0" />
     <PackageVersion Include="JetBrains.Annotations" Version="2025.2.4" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.5" />

--- a/tests/BrowserPicker.Common.Tests/UnitTest1.cs
+++ b/tests/BrowserPicker.Common.Tests/UnitTest1.cs
@@ -1,3 +1,8 @@
+using System.Buffers.Binary;
+using System.Net.Security;
+using System.Security.Authentication;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
 using AwesomeAssertions;
 
 namespace BrowserPicker.Common.Tests;
@@ -177,5 +182,231 @@ public class UrlSecurityPresentationTests
 
 		setting.MatchLength(fileUrl).Should().Be(0);
 		setting.MatchLength(httpsUrl).Should().Be("company.com".Length);
+	}
+
+	[Fact]
+	public void TlsCertificateSummaryReportsSanHostMatch()
+	{
+		using var certificate = CreateCertificate("example.com", "example.com", "*.example.org");
+
+		var summary = TlsCertificateSummary.FromCertificate(
+			new Uri("https://www.example.org/path"),
+			certificate,
+			SslPolicyErrors.None,
+			[],
+			SslProtocols.Tls13,
+			TlsCipherSuite.TLS_AES_256_GCM_SHA384
+		);
+
+		summary.HostNameMatchesCertificate.Should().BeTrue();
+		summary.SubjectAlternativeNames.Should().Equal("example.com", "*.example.org");
+		summary.ToDisplayText().Should().Contain("Validation: Valid");
+		summary.ToDisplayText().Should().Contain("Host match: Yes (www.example.org)");
+		summary.ToDisplayText().Should().Contain("Protocol: Tls13");
+		summary.ToDisplayText().Should().Contain("Cipher strength: Strong classical (not post-quantum)");
+	}
+
+	[Fact]
+	public void TlsCertificateSummaryReportsWeakCipherStrength()
+	{
+		using var certificate = CreateCertificate("example.com", "example.com");
+
+		var summary = TlsCertificateSummary.FromCertificate(
+			new Uri("https://example.com"),
+			certificate,
+			SslPolicyErrors.None,
+			[],
+			SslProtocols.Tls12,
+			TlsCipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA
+		);
+
+		summary.ToDisplayText().Should().Contain("Cipher strength: Weak");
+	}
+
+	[Fact]
+	public void TlsCertificateSummaryReportsInsecureProtocol()
+	{
+		using var certificate = CreateCertificate("example.com", "example.com");
+
+		var summary = TlsCertificateSummary.FromCertificate(
+			new Uri("https://example.com"),
+			certificate,
+			SslPolicyErrors.None,
+			[],
+			(SslProtocols)192,
+			TlsCipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA
+		);
+
+		summary.ToDisplayText().Should().Contain("Cipher strength: Insecure");
+	}
+
+	[Fact]
+	public void TlsCertificateSummaryDoesNotOvermatchWildcards()
+	{
+		using var certificate = CreateCertificate("example.com", "*.example.org");
+
+		var summary = TlsCertificateSummary.FromCertificate(
+			new Uri("https://deep.www.example.org/path"),
+			certificate,
+			SslPolicyErrors.RemoteCertificateNameMismatch,
+			["RemoteCertificateNameMismatch"]
+		);
+
+		summary.HostNameMatchesCertificate.Should().BeFalse();
+		summary.ToDisplayText().Should().Contain("Validation: Problems found");
+		summary.ToDisplayText().Should().Contain("Host match: No (deep.www.example.org)");
+	}
+
+	[Fact]
+	public void TlsCertificateSummaryOnlyAcceptsHttpsTargets()
+	{
+		var accepted = TlsCertificateSummary.TryCreateTarget("http://example.com", out _, out var errorMessage);
+
+		accepted.Should().BeFalse();
+		errorMessage.Should().Contain("only available for HTTPS URLs");
+	}
+
+	[Fact]
+	public void TlsCertificateSummaryCanSkipCertificateRecords()
+	{
+		using var certificate = CreateCertificate("example.com", "example.com");
+
+		var summary = TlsCertificateSummary.FromCertificate(
+			new Uri("https://example.com"),
+			certificate,
+			SslPolicyErrors.None,
+			[],
+			certificateRecordsChecked: false
+		);
+
+		summary.ToDisplayText().Should().Contain("CAA / certificate transparency: Not checked");
+		summary.ToDisplayText().Should().NotContain("CAA: None");
+	}
+
+	[Fact]
+	public void TlsCertificateSummaryReportsAlignedCaaRecords()
+	{
+		using var certificate = CreateCertificate("Let's Encrypt", ["example.com"], includeEmbeddedSct: true);
+
+		var summary = TlsCertificateSummary.FromCertificate(
+			new Uri("https://example.com"),
+			certificate,
+			SslPolicyErrors.None,
+			[],
+			caaRecords: ["0 issue \"letsencrypt.org\""]
+		);
+
+		summary.ToDisplayText().Should().Contain("CAA: Aligned");
+		summary.ToDisplayText().Should().NotContain("letsencrypt.org");
+		summary.ToDisplayText().Should().Contain("Certificate transparency: Looks normal");
+		summary.ToDisplayText().Should().Contain("2 transparency timestamps");
+		summary.ToDisplayText().Should().Contain("newest 2024-02-03");
+		summary.ToDisplayText().Should().NotContain("sha256_ecdsa");
+	}
+
+	[Fact]
+	public void TlsCertificateSummaryReportsUnalignedCaaRecords()
+	{
+		using var certificate = CreateCertificate("Example CA", "example.com");
+
+		var summary = TlsCertificateSummary.FromCertificate(
+			new Uri("https://example.com"),
+			certificate,
+			SslPolicyErrors.None,
+			[],
+			caaRecords: ["0 issue \"letsencrypt.org\""]
+		);
+
+		summary.ToDisplayText().Should().Contain("CAA: Unaligned");
+		summary.ToDisplayText().Should().NotContain("letsencrypt.org");
+	}
+
+	[Fact]
+	public void TlsCertificateSummaryReportsNoCaaRecords()
+	{
+		using var certificate = CreateCertificate("Example CA", "example.com");
+
+		var summary = TlsCertificateSummary.FromCertificate(
+			new Uri("https://example.com"),
+			certificate,
+			SslPolicyErrors.None,
+			[]
+		);
+
+		summary.ToDisplayText().Should().Contain("CAA: None");
+	}
+
+	private static X509Certificate2 CreateCertificate(
+		string commonName,
+		params string[] dnsNames
+	) => CreateCertificate(commonName, dnsNames, includeEmbeddedSct: false);
+
+	private static X509Certificate2 CreateCertificate(
+		string commonName,
+		string[] dnsNames,
+		bool includeEmbeddedSct
+	)
+	{
+		using var key = RSA.Create(2048);
+		var request = new CertificateRequest(
+			$"CN={commonName}",
+			key,
+			HashAlgorithmName.SHA256,
+			RSASignaturePadding.Pkcs1
+		);
+		var subjectAlternativeNames = new SubjectAlternativeNameBuilder();
+		foreach (var dnsName in dnsNames)
+		{
+			subjectAlternativeNames.AddDnsName(dnsName);
+		}
+		request.CertificateExtensions.Add(subjectAlternativeNames.Build());
+		if (includeEmbeddedSct)
+		{
+			request.CertificateExtensions.Add(
+				new X509Extension("1.3.6.1.4.1.11129.2.4.2", BuildEmbeddedSctExtension(), critical: false)
+			);
+		}
+
+		return request.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(30));
+	}
+
+	private static byte[] BuildEmbeddedSctExtension()
+	{
+		var first = BuildSignedCertificateTimestamp(0x11, new DateTimeOffset(2024, 1, 2, 3, 4, 5, TimeSpan.Zero));
+		var second = BuildSignedCertificateTimestamp(0x22, new DateTimeOffset(2024, 2, 3, 4, 5, 6, TimeSpan.Zero));
+		var listLength = 2 + first.Length + 2 + second.Length;
+		var extension = new byte[2 + listLength];
+		BinaryPrimitives.WriteUInt16BigEndian(extension.AsSpan(0, 2), (ushort)listLength);
+		var offset = 2;
+		WriteSerializedSct(extension, ref offset, first);
+		WriteSerializedSct(extension, ref offset, second);
+		return extension;
+	}
+
+	private static byte[] BuildSignedCertificateTimestamp(byte logIdByte, DateTimeOffset timestamp)
+	{
+		var sct = new byte[1 + 32 + 8 + 2 + 2 + 2 + 1];
+		var offset = 0;
+		sct[offset++] = 0;
+		sct.AsSpan(offset, 32).Fill(logIdByte);
+		offset += 32;
+		BinaryPrimitives.WriteUInt64BigEndian(sct.AsSpan(offset, 8), (ulong)timestamp.ToUnixTimeMilliseconds());
+		offset += 8;
+		BinaryPrimitives.WriteUInt16BigEndian(sct.AsSpan(offset, 2), 0);
+		offset += 2;
+		sct[offset++] = 4;
+		sct[offset++] = 3;
+		BinaryPrimitives.WriteUInt16BigEndian(sct.AsSpan(offset, 2), 1);
+		offset += 2;
+		sct[offset] = 0xff;
+		return sct;
+	}
+
+	private static void WriteSerializedSct(byte[] extension, ref int offset, byte[] sct)
+	{
+		BinaryPrimitives.WriteUInt16BigEndian(extension.AsSpan(offset, 2), (ushort)sct.Length);
+		offset += 2;
+		sct.CopyTo(extension, offset);
+		offset += sct.Length;
 	}
 }

--- a/tests/BrowserPicker.Common.Tests/UnitTest1.cs
+++ b/tests/BrowserPicker.Common.Tests/UnitTest1.cs
@@ -336,16 +336,10 @@ public class UrlSecurityPresentationTests
 		summary.ToDisplayText().Should().Contain("CAA: None");
 	}
 
-	private static X509Certificate2 CreateCertificate(
-		string commonName,
-		params string[] dnsNames
-	) => CreateCertificate(commonName, dnsNames, includeEmbeddedSct: false);
+	private static X509Certificate2 CreateCertificate(string commonName, params string[] dnsNames) =>
+		CreateCertificate(commonName, dnsNames, includeEmbeddedSct: false);
 
-	private static X509Certificate2 CreateCertificate(
-		string commonName,
-		string[] dnsNames,
-		bool includeEmbeddedSct
-	)
+	private static X509Certificate2 CreateCertificate(string commonName, string[] dnsNames, bool includeEmbeddedSct)
 	{
 		using var key = RSA.Create(2048);
 		var request = new CertificateRequest(


### PR DESCRIPTION
## Summary
- Adds a user-triggered HTTPS connection check dialog with confirmation, cancellation, TLS certificate details, cipher strength, CAA alignment, and certificate transparency guidance.
- Adds security settings for certificate record checks, hiding the manual scan action, and skipping the confirmation prompt, including profile and settings persistence updates.
- Replaces the main picker text action with a padlock indicator that reflects scan results without using traffic-light colors for DNS resolution failures.

## Test plan
- [x] dotnet test tests/BrowserPicker.Common.Tests/BrowserPicker.Common.Tests.csproj

Fixes #248

Made with [Cursor](https://cursor.com)