### PR TITLE
Add user-only portable browser registration

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,13 @@ If you do not want to have the .net runtime installed on your computer, you may 
 `BrowserPicker-Portable.msi` and `Portable.zip` contain a win-x64 binary executable with embedded .NET runtime.  
 This makes the file sizes quite significantly larger, but you do not need an additional runtime to use these.
 
+#### Portable default browser registration
+The portable build can register itself for the current Windows user as `Browser Picker (Portable)`, using `HKCU` rather than requiring administrator access. This keeps it distinct from the normal installed `Browser Picker` registration.
+
+When the release portable app starts, it automatically adds this current-user registration if Browser Picker is not already installed for the machine, or if the installed machine-wide registration points to a different executable. If a portable registration already exists and points somewhere else, Browser Picker leaves it alone; use the settings window to change it manually.
+
+You can manage this from `Behaviour` -> `Windows integration`. The button registers `Browser Picker (Portable)` when it is missing, and changes to an unregister action when the current user registration exists. This option is hidden when the running executable is already the machine-wide `Browser Picker` install.
+
 ### Signing certificate
 To avoid warnings about unknown publisher, you may [import](https://stackoverflow.com/questions/49039136/powershell-script-to-install-trusted-publisher-certificates) the provided certificate into your certificate store first.
 

--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,7 @@ This makes the file sizes quite significantly larger, but you do not need an add
 #### Portable default browser registration
 The portable build can register itself for the current Windows user as `Browser Picker (Portable)`, using `HKCU` rather than requiring administrator access. This keeps it distinct from the normal installed `Browser Picker` registration.
 
-When the release portable app starts, it automatically adds this current-user registration if Browser Picker is not already installed for the machine, or if the installed machine-wide registration points to a different executable. If a portable registration already exists and points somewhere else, Browser Picker leaves it alone; use the settings window to change it manually.
+When the release portable app starts, it automatically adds this current-user registration if Browser Picker is not already installed for the machine, or if the installed machine-wide registration points to a different executable. This behavior is only built into portable builds. If a portable registration already exists and points somewhere else, Browser Picker leaves it alone; use the settings window to change it manually.
 
 You can manage this from `Behaviour` -> `Windows integration`. The button registers `Browser Picker (Portable)` when it is missing, and changes to an unregister action when the current user registration exists. This option is hidden when the running executable is already the machine-wide `Browser Picker` install.
 

--- a/src/BrowserPicker.UI/Program.cs
+++ b/src/BrowserPicker.UI/Program.cs
@@ -68,7 +68,7 @@ internal static class Program
 		app.AddContentThemeDictionary(configuration.ThemeMode);
 		var logger = host.Services.GetRequiredService<ILogger<App>>();
 		logger.LogApplicationLaunched(args.Length == 0 ? "(none)" : string.Join(" ", args));
-#if !DEBUG
+#if !DEBUG && BROWSERPICKER_PORTABLE
 		var registrationResult = UserDefaultBrowserRegistration.RegisterForCurrentUserIfPortableRelease(
 			out var registrationDetail
 		);

--- a/src/BrowserPicker.UI/Program.cs
+++ b/src/BrowserPicker.UI/Program.cs
@@ -68,6 +68,16 @@ internal static class Program
 		app.AddContentThemeDictionary(configuration.ThemeMode);
 		var logger = host.Services.GetRequiredService<ILogger<App>>();
 		logger.LogApplicationLaunched(args.Length == 0 ? "(none)" : string.Join(" ", args));
+#if !DEBUG
+		var registrationResult = UserDefaultBrowserRegistration.RegisterForCurrentUserIfPortableRelease(
+			out var registrationDetail
+		);
+		logger.LogInformation(
+			"Portable browser registration check completed with {Result}. {Detail}",
+			registrationResult,
+			registrationDetail ?? string.Empty
+		);
+#endif
 
 		app.Run();
 	}

--- a/src/BrowserPicker.UI/Properties/launchSettings.json
+++ b/src/BrowserPicker.UI/Properties/launchSettings.json
@@ -41,6 +41,13 @@
       "environmentVariables": {
         "DOTNET_ENVIRONMENT": "Development"
       }
+    },
+    "punyCode": {
+      "commandName": "Project",
+      "commandLineArgs": "https://xn--exmple-cua.local/login",
+      "environmentVariables": {
+        "DOTNET_ENVIRONMENT": "Development"
+      }
     }
   }
 }

--- a/src/BrowserPicker.UI/ViewModels/ConfigurationViewModel.cs
+++ b/src/BrowserPicker.UI/ViewModels/ConfigurationViewModel.cs
@@ -682,6 +682,7 @@ public sealed class ConfigurationViewModel : ModelBase
 
 	private void ToggleCurrentUserBrowserRegistration()
 	{
+#if BROWSERPICKER_PORTABLE
 		try
 		{
 			if (BrowserRegisteredForCurrentUser)
@@ -703,12 +704,21 @@ public sealed class ConfigurationViewModel : ModelBase
 			BrowserRegistrationStatus = $"Unable to update Browser Picker registration: {ex.Message}";
 			RefreshBrowserRegistrationState();
 		}
+#else
+		BrowserRegistrationStatus = "Current-user browser registration is only available in portable builds.";
+		RefreshBrowserRegistrationState();
+#endif
 	}
 
 	private void RefreshBrowserRegistrationState()
 	{
+#if BROWSERPICKER_PORTABLE
 		ShowCurrentUserBrowserRegistration = !UserDefaultBrowserRegistration.IsCurrentExecutableMachineRegistered();
 		BrowserRegisteredForCurrentUser = UserDefaultBrowserRegistration.IsRegisteredForCurrentUser();
+#else
+		ShowCurrentUserBrowserRegistration = false;
+		BrowserRegisteredForCurrentUser = false;
+#endif
 	}
 
 	internal void ShowFeedbackTab()

--- a/src/BrowserPicker.UI/ViewModels/ConfigurationViewModel.cs
+++ b/src/BrowserPicker.UI/ViewModels/ConfigurationViewModel.cs
@@ -222,6 +222,7 @@ public sealed class ConfigurationViewModel : ModelBase
 			Defaults.Add(setting);
 		}
 		settings.PropertyChanged += Configuration_PropertyChanged;
+		RefreshBrowserRegistrationState();
 	}
 
 	/// <summary>
@@ -525,6 +526,12 @@ public sealed class ConfigurationViewModel : ModelBase
 	public ICommand AddShortener => add_shortener ??= new DelegateCommand<string>(AddUrlShortener, CanAddShortener);
 
 	/// <summary>
+	/// Command to register or unregister Browser Picker as a browser for the current Windows user.
+	/// </summary>
+	public ICommand RegisterBrowserForCurrentUser =>
+		register_browser_for_current_user ??= new DelegateCommand(ToggleCurrentUserBrowserRegistration);
+
+	/// <summary>
 	/// Command to remove a URL shortener domain; parameter is the domain string.
 	/// </summary>
 	public ICommand RemoveShortener =>
@@ -561,6 +568,47 @@ public sealed class ConfigurationViewModel : ModelBase
 			apply_security_profile?.RaiseCanExecuteChanged();
 		}
 	}
+
+	/// <summary>
+	/// Status text for the current-user Windows browser registration action.
+	/// </summary>
+	public string BrowserRegistrationStatus
+	{
+		get => browser_registration_status;
+		private set => SetProperty(ref browser_registration_status, value);
+	}
+
+	/// <summary>
+	/// True after Browser Picker has been registered as a browser for the current Windows user.
+	/// </summary>
+	public bool BrowserRegisteredForCurrentUser
+	{
+		get => browser_registered_for_current_user;
+		private set
+		{
+			if (!SetProperty(ref browser_registered_for_current_user, value))
+			{
+				return;
+			}
+
+			OnPropertyChanged(nameof(BrowserRegistrationActionText));
+			OnPropertyChanged(nameof(BrowserRegistrationDescription));
+		}
+	}
+
+	public bool ShowCurrentUserBrowserRegistration
+	{
+		get => show_current_user_browser_registration;
+		private set => SetProperty(ref show_current_user_browser_registration, value);
+	}
+
+	public string BrowserRegistrationActionText =>
+		BrowserRegisteredForCurrentUser ? "Unregister for current user" : "Register for current user";
+
+	public string BrowserRegistrationDescription =>
+		BrowserRegisteredForCurrentUser
+			? "Browser Picker (Portable) is registered for this Windows user."
+			: "Register Browser Picker for this Windows user without requiring administrator privileges.";
 
 	/// <summary>
 	/// Prompts the user to select a backup file location and saves the current settings.
@@ -630,6 +678,37 @@ public sealed class ConfigurationViewModel : ModelBase
 		}
 
 		jsonSettings.TryImportSettingsJson(text!, "the clipboard");
+	}
+
+	private void ToggleCurrentUserBrowserRegistration()
+	{
+		try
+		{
+			if (BrowserRegisteredForCurrentUser)
+			{
+				UserDefaultBrowserRegistration.UnregisterForCurrentUser();
+				BrowserRegistrationStatus = "Unregistered Browser Picker (Portable) for this Windows user.";
+			}
+			else
+			{
+				UserDefaultBrowserRegistration.RegisterForCurrentUser();
+				BrowserRegistrationStatus =
+					"Registered Browser Picker (Portable) for this Windows user. If it is not selected yet, choose it in Windows Default apps.";
+			}
+
+			RefreshBrowserRegistrationState();
+		}
+		catch (Exception ex)
+		{
+			BrowserRegistrationStatus = $"Unable to update Browser Picker registration: {ex.Message}";
+			RefreshBrowserRegistrationState();
+		}
+	}
+
+	private void RefreshBrowserRegistrationState()
+	{
+		ShowCurrentUserBrowserRegistration = !UserDefaultBrowserRegistration.IsCurrentExecutableMachineRegistered();
+		BrowserRegisteredForCurrentUser = UserDefaultBrowserRegistration.IsRegisteredForCurrentUser();
 	}
 
 	internal void ShowFeedbackTab()
@@ -1027,9 +1106,13 @@ public sealed class ConfigurationViewModel : ModelBase
 	private DelegateCommand? restore;
 	private DelegateCommand? copy_settings;
 	private DelegateCommand? paste_settings;
+	private DelegateCommand? register_browser_for_current_user;
 	private DelegateCommand<string>? add_shortener;
 	private DelegateCommand<string>? remove_shortener;
 	private DelegateCommand<ISecurityProfile>? apply_security_profile;
+	private string browser_registration_status = string.Empty;
+	private bool browser_registered_for_current_user;
+	private bool show_current_user_browser_registration;
 
 	private string? test_defaults_url;
 

--- a/src/BrowserPicker.UI/Views/Configuration.xaml
+++ b/src/BrowserPicker.UI/Views/Configuration.xaml
@@ -465,6 +465,28 @@
 								</StackPanel>
 							</StackPanel>
 
+							<StackPanel>
+								<StackPanel.Style>
+									<Style TargetType="StackPanel">
+										<Setter Property="Visibility" Value="Visible" />
+										<Style.Triggers>
+											<DataTrigger Binding="{Binding ShowCurrentUserBrowserRegistration}" Value="False">
+												<Setter Property="Visibility" Value="Collapsed" />
+											</DataTrigger>
+										</Style.Triggers>
+									</Style>
+								</StackPanel.Style>
+								<TextBlock Margin="0,16,0,6" FontWeight="Bold" Text="Windows integration" />
+								<TextBlock Margin="0,0,0,6" Text="{Binding BrowserRegistrationDescription}" TextWrapping="Wrap" />
+								<Button
+									HorizontalAlignment="Left"
+									Margin="0,0,0,6"
+									Padding="10,4"
+									Command="{Binding RegisterBrowserForCurrentUser}"
+									Content="{Binding BrowserRegistrationActionText}" />
+								<TextBlock FontSize="11" Text="{Binding BrowserRegistrationStatus}" TextWrapping="Wrap" />
+							</StackPanel>
+
 						</StackPanel>
 					</Grid>
 				</ScrollViewer>

--- a/src/BrowserPicker.UI/Views/Configuration.xaml
+++ b/src/BrowserPicker.UI/Views/Configuration.xaml
@@ -479,9 +479,9 @@
 								<TextBlock Margin="0,16,0,6" FontWeight="Bold" Text="Windows integration" />
 								<TextBlock Margin="0,0,0,6" Text="{Binding BrowserRegistrationDescription}" TextWrapping="Wrap" />
 								<Button
-									HorizontalAlignment="Left"
 									Margin="0,0,0,6"
 									Padding="10,4"
+									HorizontalAlignment="Left"
 									Command="{Binding RegisterBrowserForCurrentUser}"
 									Content="{Binding BrowserRegistrationActionText}" />
 								<TextBlock FontSize="11" Text="{Binding BrowserRegistrationStatus}" TextWrapping="Wrap" />

--- a/src/BrowserPicker.Windows/UserDefaultBrowserRegistration.cs
+++ b/src/BrowserPicker.Windows/UserDefaultBrowserRegistration.cs
@@ -1,0 +1,284 @@
+using System;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Reflection;
+using Microsoft.Win32;
+
+namespace BrowserPicker.Windows;
+
+public enum CurrentUserBrowserRegistrationResult
+{
+	Registered,
+	AlreadyRegisteredForCurrentUser,
+	CurrentExecutableMachineRegistered,
+	ExecutablePathUnavailable,
+	RegistrationFailed,
+}
+
+/// <summary>
+/// Registers Browser Picker as a browser for the current Windows user.
+/// </summary>
+public static class UserDefaultBrowserRegistration
+{
+	private const string ApplicationName = "Browser Picker (Portable)";
+	private const string ApplicationId = "BrowserPickerPortable";
+	private const string ProgId = "BrowserPickerPortable";
+	private const string ApplicationDescription = "Shows a prompt to let you use different browsers on the fly.";
+	private const string ApplicationCapabilitiesKey = @"Software\BrowserPickerPortable\Capabilities";
+	private const string RegisteredApplicationsKey = @"Software\RegisteredApplications";
+	private const string MachineBrowserPickerCommandKey = @"SOFTWARE\BrowserPicker\Capabilities\shell\open\command";
+
+	public static void RegisterForCurrentUser()
+	{
+		if (!TryRegisterForCurrentUser(out var error))
+		{
+			throw new InvalidOperationException(error);
+		}
+	}
+
+	public static CurrentUserBrowserRegistrationResult RegisterForCurrentUserIfPortableRelease(out string? detail)
+	{
+		detail = null;
+		if (!TryGetExecutablePath(out var executablePath, out var error))
+		{
+			detail = error;
+			return CurrentUserBrowserRegistrationResult.ExecutablePathUnavailable;
+		}
+
+		if (IsRegisteredForCurrentUser())
+		{
+			detail = "Browser Picker (Portable) is already registered for the current user.";
+			return CurrentUserBrowserRegistrationResult.AlreadyRegisteredForCurrentUser;
+		}
+
+		var machineExecutablePath = GetMachineRegisteredExecutablePath();
+		if (machineExecutablePath != null && PathsEqual(executablePath, machineExecutablePath))
+		{
+			detail = $"Current executable matches machine registration: {machineExecutablePath}";
+			return CurrentUserBrowserRegistrationResult.CurrentExecutableMachineRegistered;
+		}
+
+		if (TryRegisterForCurrentUser(out error))
+		{
+			detail = $"Registered Browser Picker (Portable) for {executablePath}.";
+			return CurrentUserBrowserRegistrationResult.Registered;
+		}
+
+		detail = error;
+		return CurrentUserBrowserRegistrationResult.RegistrationFailed;
+	}
+
+	public static bool IsCurrentExecutableMachineRegistered()
+	{
+		if (!TryGetExecutablePath(out var executablePath, out _))
+		{
+			return false;
+		}
+
+		var machineExecutablePath = GetMachineRegisteredExecutablePath();
+		return machineExecutablePath != null && PathsEqual(executablePath, machineExecutablePath);
+	}
+
+	public static void UnregisterForCurrentUser()
+	{
+		using var registeredApplications = Registry.CurrentUser.OpenSubKey(RegisteredApplicationsKey, true);
+		registeredApplications?.DeleteValue(ApplicationId, throwOnMissingValue: false);
+
+		Registry.CurrentUser.DeleteSubKeyTree(@"Software\BrowserPickerPortable", throwOnMissingSubKey: false);
+		Registry.CurrentUser.DeleteSubKeyTree(@"Software\Classes\" + ProgId, throwOnMissingSubKey: false);
+	}
+
+	public static bool IsRegisteredForCurrentUser()
+	{
+		try
+		{
+			using var registeredApplications = Registry.CurrentUser.OpenSubKey(RegisteredApplicationsKey, false);
+			return string.Equals(
+				registeredApplications?.GetValue(ApplicationId) as string,
+				ApplicationCapabilitiesKey,
+				StringComparison.OrdinalIgnoreCase
+			);
+		}
+		catch
+		{
+			return false;
+		}
+	}
+
+	private static bool TryRegisterForCurrentUser([NotNullWhen(false)] out string? error)
+	{
+		error = null;
+		try
+		{
+			if (!TryGetExecutablePath(out var executablePath, out error))
+			{
+				return false;
+			}
+
+			RemoveLegacyCurrentUserRegistration();
+
+			RegisterProgId(executablePath);
+			RegisterCapabilities(ApplicationCapabilitiesKey, executablePath);
+
+			using var registeredApplications = Registry.CurrentUser.CreateSubKey(RegisteredApplicationsKey);
+			if (registeredApplications == null)
+			{
+				error = @"Unable to create HKCU\Software\RegisteredApplications.";
+				return false;
+			}
+
+			registeredApplications.SetValue(ApplicationId, ApplicationCapabilitiesKey, RegistryValueKind.String);
+			return true;
+		}
+		catch (Exception ex)
+		{
+			error = ex.Message;
+			return false;
+		}
+	}
+
+	private static void RegisterProgId(string executablePath)
+	{
+		using var progId = Registry.CurrentUser.CreateSubKey(@"Software\Classes\" + ProgId);
+		progId.SetValue(null, ApplicationName, RegistryValueKind.String);
+		progId.SetValue("EditFlags", 2, RegistryValueKind.DWord);
+		progId.SetValue("FriendlyTypeName", "Web URL", RegistryValueKind.String);
+		progId.SetValue("URL Protocol", string.Empty, RegistryValueKind.String);
+
+		using var icon = progId.CreateSubKey("DefaultIcon");
+		icon.SetValue(null, $"{executablePath},0", RegistryValueKind.String);
+
+		using var shell = progId.CreateSubKey("shell");
+		shell.SetValue(null, "open", RegistryValueKind.String);
+
+		using var command = progId.CreateSubKey(@"shell\open\command");
+		command.SetValue(null, BuildCommand(executablePath), RegistryValueKind.String);
+	}
+
+	private static void RegisterCapabilities(string keyPath, string executablePath)
+	{
+		using var capabilities = Registry.CurrentUser.CreateSubKey(keyPath);
+		capabilities.SetValue("ApplicationDescription", ApplicationDescription, RegistryValueKind.String);
+		capabilities.SetValue("ApplicationIcon", $"{executablePath},0", RegistryValueKind.String);
+		capabilities.SetValue("ApplicationName", ApplicationName, RegistryValueKind.String);
+
+		using var defaultIcon = capabilities.CreateSubKey("DefaultIcon");
+		defaultIcon.SetValue(null, $"{executablePath},0", RegistryValueKind.String);
+
+		using var fileAssociations = capabilities.CreateSubKey("FileAssociations");
+		fileAssociations.SetValue(".html", ProgId, RegistryValueKind.String);
+		fileAssociations.SetValue(".htm", ProgId, RegistryValueKind.String);
+
+		using var startMenu = capabilities.CreateSubKey("StartMenu");
+		startMenu.SetValue("StartMenuInternet", ApplicationId, RegistryValueKind.String);
+
+		using var urlAssociations = capabilities.CreateSubKey("URLAssociations");
+		urlAssociations.SetValue("ftp", ProgId, RegistryValueKind.String);
+		urlAssociations.SetValue("http", ProgId, RegistryValueKind.String);
+		urlAssociations.SetValue("https", ProgId, RegistryValueKind.String);
+
+		using var shell = capabilities.CreateSubKey("shell");
+		shell.SetValue(null, "open", RegistryValueKind.String);
+
+		using var command = capabilities.CreateSubKey(@"shell\open\command");
+		command.SetValue(null, BuildCommand(executablePath), RegistryValueKind.String);
+	}
+
+	private static string BuildCommand(string executablePath) => $"\"{executablePath}\" \"%1\"";
+
+	private static string? GetMachineRegisteredExecutablePath()
+	{
+		try
+		{
+			using var command = Registry.LocalMachine.OpenSubKey(MachineBrowserPickerCommandKey, false);
+			return TryGetExecutablePathFromCommand(command?.GetValue(null) as string, out var executablePath)
+				? executablePath
+				: null;
+		}
+		catch
+		{
+			return null;
+		}
+	}
+
+	private static bool TryGetExecutablePathFromCommand(string? command, [NotNullWhen(true)] out string? executablePath)
+	{
+		executablePath = null;
+		if (string.IsNullOrWhiteSpace(command))
+		{
+			return false;
+		}
+
+		var trimmed = command.Trim();
+		if (trimmed.StartsWith('"'))
+		{
+			var endQuote = trimmed.IndexOf('"', 1);
+			if (endQuote > 1)
+			{
+				executablePath = trimmed[1..endQuote];
+				return true;
+			}
+		}
+
+		var exeIndex = trimmed.IndexOf(".exe", StringComparison.OrdinalIgnoreCase);
+		if (exeIndex < 0)
+		{
+			return false;
+		}
+
+		executablePath = trimmed[..(exeIndex + 4)];
+		return true;
+	}
+
+	private static bool PathsEqual(string first, string second)
+	{
+		try
+		{
+			return string.Equals(Path.GetFullPath(first), Path.GetFullPath(second), StringComparison.OrdinalIgnoreCase);
+		}
+		catch
+		{
+			return string.Equals(first, second, StringComparison.OrdinalIgnoreCase);
+		}
+	}
+
+	private static void RemoveLegacyCurrentUserRegistration()
+	{
+		using var registeredApplications = Registry.CurrentUser.OpenSubKey(RegisteredApplicationsKey, true);
+		registeredApplications?.DeleteValue("BrowserPicker", throwOnMissingValue: false);
+
+		Registry.CurrentUser.DeleteSubKeyTree(@"Software\BrowserPicker\Capabilities", throwOnMissingSubKey: false);
+		Registry.CurrentUser.DeleteSubKeyTree(
+			@"Software\Clients\StartMenuInternet\BrowserPicker",
+			throwOnMissingSubKey: false
+		);
+		Registry.CurrentUser.DeleteSubKeyTree(@"Software\Classes\BrowserPicker", throwOnMissingSubKey: false);
+	}
+
+	private static bool TryGetExecutablePath(
+		[NotNullWhen(true)] out string? executablePath,
+		[NotNullWhen(false)] out string? error
+	)
+	{
+		executablePath =
+			Environment.ProcessPath
+			?? Assembly.GetEntryAssembly()?.Location
+			?? Process.GetCurrentProcess().MainModule?.FileName;
+
+		if (string.IsNullOrWhiteSpace(executablePath))
+		{
+			error = "Unable to determine the Browser Picker executable path.";
+			return false;
+		}
+
+		if (!File.Exists(executablePath))
+		{
+			error = $"The Browser Picker executable was not found: {executablePath}";
+			return false;
+		}
+
+		error = null;
+		return true;
+	}
+}

--- a/src/BrowserPicker.Windows/UserDefaultBrowserRegistration.cs
+++ b/src/BrowserPicker.Windows/UserDefaultBrowserRegistration.cs
@@ -1,3 +1,4 @@
+#if BROWSERPICKER_PORTABLE
 using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -282,3 +283,4 @@ public static class UserDefaultBrowserRegistration
 		return true;
 	}
 }
+#endif

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -12,6 +12,12 @@
     <!-- UseArtifactsOutput not supported by WixToolset.Sdk -->
     <!--<UseArtifactsOutput>true</UseArtifactsOutput>-->
   </PropertyGroup>
+  <PropertyGroup Condition="'$(BrowserPickerPortable)' == '' and '$(PublishSingleFile)' == 'true'">
+    <BrowserPickerPortable>true</BrowserPickerPortable>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(BrowserPickerPortable)' == 'true'">
+    <DefineConstants>$(DefineConstants);BROWSERPICKER_PORTABLE</DefineConstants>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'SignedRelease|AnyCPU'">
     <OutputPath>bin\SignedRelease\</OutputPath>
     <Optimize>true</Optimize>


### PR DESCRIPTION
## Summary
- Add current-user registration for portable Browser Picker as `Browser Picker (Portable)` without requiring administrator privileges.
- Compile the portable registration code only for portable builds via `BROWSERPICKER_PORTABLE`.
- Auto-register release portable builds only when the machine-wide install does not already match, and log the registration outcome.
- Add a settings toggle to register/unregister the portable HKCU registration and document the behavior.
- Add a punycode launch profile for local IDN testing.

Fixes #278

## Test plan
- `dotnet build "src\BrowserPicker.UI\BrowserPicker.UI.csproj" -p:Version=1.0.0`
- `dotnet build "src\BrowserPicker.UI\BrowserPicker.UI.csproj" -c Release -p:Version=1.0.0`
- `dotnet build "src\BrowserPicker.UI\BrowserPicker.UI.csproj" -c Release -p:Version=1.0.0 -p:BrowserPickerPortable=true`
