### PR TITLE
Use application icon for registered URL handlers

### DIFF
--- a/dist/Dependent/Product.wxs
+++ b/dist/Dependent/Product.wxs
@@ -59,7 +59,7 @@
 				<RegistryValue Root="HKCR" Key="BrowserPicker" Name="EditFlags" Value="2" Type="integer" />
 				<RegistryValue Root="HKCR" Key="BrowserPicker" Name="FriendlyTypeName" Value="Web URL" Type="string" />
 				<RegistryValue Root="HKCR" Key="BrowserPicker" Name="URL Protocol" Value="" Type="string" />
-				<RegistryValue Root="HKCR" Key="BrowserPicker\DefaultIcon" Value="[INSTALLFOLDER]BrowserPicker.exe,1" Type="string" />
+				<RegistryValue Root="HKCR" Key="BrowserPicker\DefaultIcon" Value="[INSTALLFOLDER]BrowserPicker.exe,0" Type="string" />
 				<RegistryValue Root="HKCR" Key="BrowserPicker\shell" Type="string" Value="open" />
 				<RegistryValue Root="HKCR" Key="BrowserPicker\shell\open\command" Type="string" Value="&quot;[INSTALLFOLDER]BrowserPicker.exe&quot; &quot;%1&quot;" />
 
@@ -67,7 +67,7 @@
 				<RegistryValue Root="HKLM" Key="SOFTWARE\BrowserPicker\Capabilities" Name="ApplicationDescription" Value="Shows a prompt to let you use different browsers on the fly." Type="string" />
 				<RegistryValue Root="HKLM" Key="SOFTWARE\BrowserPicker\Capabilities" Name="ApplicationIcon" Value="[INSTALLFOLDER]BrowserPicker.exe,0" Type="string" />
 				<RegistryValue Root="HKLM" Key="SOFTWARE\BrowserPicker\Capabilities" Name="ApplicationName" Value="Browser Picker" Type="string" />
-				<RegistryValue Root="HKLM" Key="SOFTWARE\BrowserPicker\Capabilities\DefaultIcon" Value="[INSTALLFOLDER]BrowserPicker.exe,1" Type="string" />
+				<RegistryValue Root="HKLM" Key="SOFTWARE\BrowserPicker\Capabilities\DefaultIcon" Value="[INSTALLFOLDER]BrowserPicker.exe,0" Type="string" />
 				<RegistryValue Root="HKLM" Key="SOFTWARE\BrowserPicker\Capabilities\FileAssociations" Name=".html" Value="BrowserPicker" Type="string" />
 				<RegistryValue Root="HKLM" Key="SOFTWARE\BrowserPicker\Capabilities\FileAssociations" Name=".htm" Value="BrowserPicker" Type="string" />
 				<RegistryValue Root="HKLM" Key="SOFTWARE\BrowserPicker\Capabilities\StartMenu" Name="StartMenuInternet" Value="BrowserPicker" Type="string" />

--- a/dist/Portable/Product.wxs
+++ b/dist/Portable/Product.wxs
@@ -40,7 +40,7 @@
 				<RegistryValue Root="HKCR" Key="BrowserPicker" Name="EditFlags" Value="2" Type="integer" />
 				<RegistryValue Root="HKCR" Key="BrowserPicker" Name="FriendlyTypeName" Value="Web URL" Type="string" />
 				<RegistryValue Root="HKCR" Key="BrowserPicker" Name="URL Protocol" Value="" Type="string" />
-				<RegistryValue Root="HKCR" Key="BrowserPicker\DefaultIcon" Value="[INSTALLFOLDER]BrowserPicker.exe,1" Type="string" />
+				<RegistryValue Root="HKCR" Key="BrowserPicker\DefaultIcon" Value="[INSTALLFOLDER]BrowserPicker.exe,0" Type="string" />
 				<RegistryValue Root="HKCR" Key="BrowserPicker\shell" Type="string" Value="open" />
 				<RegistryValue Root="HKCR" Key="BrowserPicker\shell\open\command" Type="string" Value="&quot;[INSTALLFOLDER]BrowserPicker.exe&quot; &quot;%1&quot;" />
 
@@ -48,7 +48,7 @@
 				<RegistryValue Root="HKLM" Key="SOFTWARE\BrowserPicker\Capabilities" Name="ApplicationDescription" Value="Shows a prompt to let you use different browsers on the fly." Type="string" />
 				<RegistryValue Root="HKLM" Key="SOFTWARE\BrowserPicker\Capabilities" Name="ApplicationIcon" Value="[INSTALLFOLDER]BrowserPicker.exe,0" Type="string" />
 				<RegistryValue Root="HKLM" Key="SOFTWARE\BrowserPicker\Capabilities" Name="ApplicationName" Value="Browser Picker" Type="string" />
-				<RegistryValue Root="HKLM" Key="SOFTWARE\BrowserPicker\Capabilities\DefaultIcon" Value="[INSTALLFOLDER]BrowserPicker.exe,1" Type="string" />
+				<RegistryValue Root="HKLM" Key="SOFTWARE\BrowserPicker\Capabilities\DefaultIcon" Value="[INSTALLFOLDER]BrowserPicker.exe,0" Type="string" />
 				<RegistryValue Root="HKLM" Key="SOFTWARE\BrowserPicker\Capabilities\FileAssociations" Name=".html" Value="BrowserPicker" Type="string" />
 				<RegistryValue Root="HKLM" Key="SOFTWARE\BrowserPicker\Capabilities\FileAssociations" Name=".htm" Value="BrowserPicker" Type="string" />
 				<RegistryValue Root="HKLM" Key="SOFTWARE\BrowserPicker\Capabilities\StartMenu" Name="StartMenuInternet" Value="BrowserPicker" Type="string" />


### PR DESCRIPTION
## Summary
- Use the executable's application icon index for BrowserPicker protocol/default icon registration.
- Align dependent and portable MSI registry entries so URL handlers do not point at a missing icon resource.

## Test plan
- Not run; WiX registry value-only change.

Refs #279