### PR TITLE
Fix browser launches from CLI tools that quote the URL (#296)

### DIFF
--- a/src/BrowserPicker.Common/UrlHandler.cs
+++ b/src/BrowserPicker.Common/UrlHandler.cs
@@ -33,6 +33,7 @@ public sealed class UrlHandler : ModelBase, ILongRunningProcess
 	public UrlHandler(ILogger<UrlHandler> logger, string? requestedUrl, IApplicationSettings settings)
 	{
 		this.logger = logger;
+		requestedUrl = NormalizeRequestedUrl(requestedUrl);
 		logger.LogRequestedUrl(requestedUrl);
 		var canProbe = requestedUrl != null;
 		probe_redirects = canProbe && settings.ProbeRedirects;
@@ -380,6 +381,33 @@ public sealed class UrlHandler : ModelBase, ILongRunningProcess
 			"favicons"
 		);
 		return Path.Combine(root, $"{host}.bin");
+	}
+
+	/// <summary>
+	/// Some callers (e.g. CLI tools such as the Claude CLI that launch via the BROWSER environment variable)
+	/// pass the URL wrapped in quotes, e.g. <c>"https://example.com"</c>. Those literal quote characters make
+	/// the value fail to parse as a <see cref="Uri"/>, leaving the host blank and skipping rule evaluation.
+	/// Strip a single matched pair of surrounding double or single quotes (and surrounding whitespace).
+	/// </summary>
+	private static string? NormalizeRequestedUrl(string? requestedUrl)
+	{
+		if (requestedUrl == null)
+		{
+			return null;
+		}
+
+		var trimmed = requestedUrl.Trim();
+		if (trimmed.Length >= 2)
+		{
+			var first = trimmed[0];
+			var last = trimmed[^1];
+			if ((first == '"' && last == '"') || (first == '\'' && last == '\''))
+			{
+				trimmed = trimmed[1..^1].Trim();
+			}
+		}
+
+		return trimmed;
 	}
 
 	private static string? ResolveJumpPage(Uri uri)

--- a/src/BrowserPicker.UI/Properties/launchSettings.json
+++ b/src/BrowserPicker.UI/Properties/launchSettings.json
@@ -48,6 +48,13 @@
       "environmentVariables": {
         "DOTNET_ENVIRONMENT": "Development"
       }
+    },
+    "quoted URL (issue 296)": {
+      "commandName": "Project",
+      "commandLineArgs": "\\\"https://github.com/mortenn/BrowserPicker\\\"",
+      "environmentVariables": {
+        "DOTNET_ENVIRONMENT": "Development"
+      }
     }
   }
 }

--- a/tests/BrowserPicker.Common.Tests/UnitTest1.cs
+++ b/tests/BrowserPicker.Common.Tests/UnitTest1.cs
@@ -4,8 +4,50 @@ using System.Security.Authentication;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using AwesomeAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace BrowserPicker.Common.Tests;
+
+public class UrlHandlerTests
+{
+	[Theory]
+	[InlineData("\"https://www.github.com/mortenn/BrowserPicker\"")]
+	[InlineData("'https://www.github.com/mortenn/BrowserPicker'")]
+	[InlineData("  \"https://www.github.com/mortenn/BrowserPicker\"  ")]
+	public void StripsSurroundingQuotesFromRequestedUrl(string requestedUrl)
+	{
+		var settings = NoNetworkSettings();
+
+		var handler = new UrlHandler(NullLogger<UrlHandler>.Instance, requestedUrl, settings);
+
+		handler.TargetURL.Should().Be("https://www.github.com/mortenn/BrowserPicker");
+		handler.HostName.Should().Be("www.github.com");
+		handler.CanRememberChoice.Should().BeTrue();
+	}
+
+	[Fact]
+	public void KeepsUnquotedRequestedUrlIntact()
+	{
+		var settings = NoNetworkSettings();
+
+		var handler = new UrlHandler(
+			NullLogger<UrlHandler>.Instance,
+			"https://www.github.com/mortenn/BrowserPicker",
+			settings
+		);
+
+		handler.TargetURL.Should().Be("https://www.github.com/mortenn/BrowserPicker");
+		handler.HostName.Should().Be("www.github.com");
+	}
+
+	private static SerializableSettings NoNetworkSettings() =>
+		new()
+		{
+			DisableNetworkAccess = true,
+			ProbeRedirects = false,
+			ProbeFavicons = false,
+		};
+}
 
 public class UrlSecurityPresentationTests
 {


### PR DESCRIPTION
## Summary
- CLI tools such as the Claude CLI launch the browser via the `BROWSER` environment variable and wrap the target URL in double quotes (e.g. `"https://..."`). Those literal quote characters reached `UrlHandler` and made `new Uri(...)` throw, leaving the host name blank — so the *remember my choice* option was empty and no rules were evaluated.
- `UrlHandler` now strips a single matched pair of surrounding double/single quotes (and whitespace) from the requested URL before parsing.
- Added a debug launch profile that reproduces the quoted-URL scenario.

## Test plan
- [x] New `UrlHandlerTests` cover double-quoted, single-quoted, whitespace-padded, and unquoted URLs.
- [x] `dotnet test tests/BrowserPicker.Common.Tests` passes (25/25).
- [x] Verified manually via the new *quoted URL (issue 296)* launch profile: URL resolves to `github.com` and the remember-choice option is populated.

Fixes #296
