### PR TITLE
Fix WPF font cache crash when launched without windir (issue #299)

### DIFF
--- a/src/BrowserPicker.Common/WindowsEnvironment.cs
+++ b/src/BrowserPicker.Common/WindowsEnvironment.cs
@@ -1,0 +1,45 @@
+using System;
+
+namespace BrowserPicker.Common;
+
+/// <summary>
+/// Helpers for repairing the process environment WPF relies on during startup.
+/// </summary>
+public static class WindowsEnvironment
+{
+	/// <summary>The environment variable WPF's font cache uses to locate the Windows Fonts directory.</summary>
+	public const string WindowsDirectoryVariable = "windir";
+
+	/// <summary>
+	/// Ensures the process-level <c>windir</c> environment variable points at a valid Windows directory.
+	/// WPF's font subsystem (<c>MS.Internal.FontCache.Util</c>) builds the Windows Fonts path from this
+	/// variable and throws <see cref="UriFormatException"/> during startup when it is missing or empty.
+	/// Some hosts (e.g. the Codex desktop app launching the Azure DevOps MCP auth flow) start
+	/// BrowserPicker with a stripped environment where <c>windir</c> is absent. See issue #299.
+	/// </summary>
+	/// <returns>The resolved Windows directory, or <see langword="null"/> when none could be determined.</returns>
+	public static string? EnsureWindowsDirectory()
+	{
+		var windir = Environment.GetEnvironmentVariable(WindowsDirectoryVariable);
+		if (!string.IsNullOrWhiteSpace(windir))
+		{
+			return windir;
+		}
+
+		// SystemRoot carries the same value and is less likely to be stripped; fall back to the
+		// OS-resolved Windows folder (which does not depend on environment variables) as a last resort.
+		var fallback = Environment.GetEnvironmentVariable("SystemRoot");
+		if (string.IsNullOrWhiteSpace(fallback))
+		{
+			fallback = Environment.GetFolderPath(Environment.SpecialFolder.Windows);
+		}
+
+		if (string.IsNullOrWhiteSpace(fallback))
+		{
+			return null;
+		}
+
+		Environment.SetEnvironmentVariable(WindowsDirectoryVariable, fallback, EnvironmentVariableTarget.Process);
+		return fallback;
+	}
+}

--- a/src/BrowserPicker.UI/Program.cs
+++ b/src/BrowserPicker.UI/Program.cs
@@ -14,6 +14,13 @@ internal static class Program
 	[STAThread]
 	private static void Main(string[] args)
 	{
+		// WPF's font subsystem (MS.Internal.FontCache.Util) builds the Windows Fonts path from the
+		// "windir" environment variable. Some hosts (e.g. the Codex desktop app launching the Azure
+		// DevOps MCP auth flow) start BrowserPicker with a stripped environment where "windir" is
+		// missing, which makes WPF throw UriFormatException during startup before any window loads.
+		// Restore it from SystemRoot / the Windows special folder so WPF can initialize. See issue #299.
+		WindowsEnvironment.EnsureWindowsDirectory();
+
 		var runtimeLogBuffer = new InMemoryLogBuffer();
 
 		var builder = Host.CreateDefaultBuilder()

--- a/tests/BrowserPicker.Common.Tests/BrowserPicker.Common.Tests.csproj
+++ b/tests/BrowserPicker.Common.Tests/BrowserPicker.Common.Tests.csproj
@@ -7,6 +7,8 @@
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
     <Platforms>x64</Platforms>
+    <!-- Required so the issue #299 regression test can touch the WPF font subsystem directly. -->
+    <UseWPF>true</UseWPF>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/BrowserPicker.Common.Tests/WindowsEnvironmentTests.cs
+++ b/tests/BrowserPicker.Common.Tests/WindowsEnvironmentTests.cs
@@ -1,0 +1,134 @@
+using AwesomeAssertions;
+
+namespace BrowserPicker.Common.Tests;
+
+/// <summary>
+/// Regression coverage for issue #299: WPF crashes during startup with a
+/// <see cref="UriFormatException"/> inside <c>MS.Internal.FontCache.Util</c> when BrowserPicker is
+/// launched (e.g. by the Codex Azure DevOps MCP auth flow) with a stripped environment that has no
+/// <c>windir</c> variable.
+///
+/// These tests mutate a process-global environment variable, so they share a non-parallel collection.
+/// </summary>
+[Collection(WindowsEnvironmentCollection.Name)]
+public sealed class WindowsEnvironmentTests
+{
+	private const string FontsSuffix = @"\Fonts\";
+
+	/// <summary>Reproduces the exact operation WPF performs, demonstrating why a missing windir crashes startup.</summary>
+	[Theory]
+	[InlineData("")]
+	[InlineData("   ")]
+	public void EmptyWindirProducesTheInvalidFontsUriThatCrashesWpf(string windir)
+	{
+		var fontsPath = windir + FontsSuffix;
+
+		var buildFontsUri = () => new Uri(fontsPath, UriKind.Absolute);
+
+		buildFontsUri.Should().Throw<UriFormatException>();
+	}
+
+	[Fact]
+	public void EnsureWindowsDirectoryRestoresAValidValueWhenMissing()
+	{
+		WithWindir(string.Empty, () =>
+		{
+			var resolved = WindowsEnvironment.EnsureWindowsDirectory();
+
+			resolved.Should().NotBeNullOrWhiteSpace();
+			Environment.GetEnvironmentVariable(WindowsEnvironment.WindowsDirectoryVariable)
+				.Should()
+				.Be(resolved);
+
+			// The whole point of the fix: WPF can now build the fonts URI without throwing.
+			var buildFontsUri = () => new Uri(resolved + FontsSuffix, UriKind.Absolute);
+			buildFontsUri.Should().NotThrow();
+		});
+	}
+
+	[Fact]
+	public void EnsureWindowsDirectoryLeavesAnExistingValueUntouched()
+	{
+		const string existing = @"C:\Windows";
+
+		WithWindir(existing, () =>
+		{
+			var resolved = WindowsEnvironment.EnsureWindowsDirectory();
+
+			resolved.Should().Be(existing);
+			Environment.GetEnvironmentVariable(WindowsEnvironment.WindowsDirectoryVariable)
+				.Should()
+				.Be(existing);
+		});
+	}
+
+	/// <summary>
+	/// The end-to-end regression test: clear windir like the crashing host does, apply the fix, then
+	/// initialize the very WPF font subsystem that threw in issue #299 and assert it no longer crashes.
+	/// </summary>
+	[Fact]
+	public void WpfFontSubsystemInitializesAfterWindirIsRestored()
+	{
+		WithWindir(string.Empty, () =>
+		{
+			WindowsEnvironment.EnsureWindowsDirectory();
+
+			var failure = TouchWpfFontSubsystem();
+
+			failure.Should().BeNull("WPF font initialization must not crash once windir is restored");
+		});
+	}
+
+	/// <summary>
+	/// Touches the WPF font types from the crash stack on a dedicated STA thread so the
+	/// <c>MS.Internal.FontCache.Util</c> static constructor runs against the current environment.
+	/// </summary>
+	private static Exception? TouchWpfFontSubsystem()
+	{
+		Exception? failure = null;
+		var thread = new Thread(() =>
+		{
+			try
+			{
+				_ = new System.Windows.Media.FontFamily("Segoe UI").FamilyNames;
+				_ = System.Windows.SystemFonts.MessageFontFamily;
+			}
+			catch (Exception exception)
+			{
+				failure = exception;
+			}
+		});
+		thread.SetApartmentState(ApartmentState.STA);
+		thread.Start();
+		thread.Join();
+		return failure;
+	}
+
+	private static void WithWindir(string? value, Action body)
+	{
+		var original = Environment.GetEnvironmentVariable(WindowsEnvironment.WindowsDirectoryVariable);
+		try
+		{
+			Environment.SetEnvironmentVariable(
+				WindowsEnvironment.WindowsDirectoryVariable,
+				value,
+				EnvironmentVariableTarget.Process
+			);
+			body();
+		}
+		finally
+		{
+			Environment.SetEnvironmentVariable(
+				WindowsEnvironment.WindowsDirectoryVariable,
+				original,
+				EnvironmentVariableTarget.Process
+			);
+		}
+	}
+}
+
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class WindowsEnvironmentCollection
+{
+	public const string Name = "WindowsEnvironment";
+}

--- a/tests/BrowserPicker.Common.Tests/WindowsEnvironmentTests.cs
+++ b/tests/BrowserPicker.Common.Tests/WindowsEnvironmentTests.cs
@@ -31,19 +31,20 @@ public sealed class WindowsEnvironmentTests
 	[Fact]
 	public void EnsureWindowsDirectoryRestoresAValidValueWhenMissing()
 	{
-		WithWindir(string.Empty, () =>
-		{
-			var resolved = WindowsEnvironment.EnsureWindowsDirectory();
+		WithWindir(
+			string.Empty,
+			() =>
+			{
+				var resolved = WindowsEnvironment.EnsureWindowsDirectory();
 
-			resolved.Should().NotBeNullOrWhiteSpace();
-			Environment.GetEnvironmentVariable(WindowsEnvironment.WindowsDirectoryVariable)
-				.Should()
-				.Be(resolved);
+				resolved.Should().NotBeNullOrWhiteSpace();
+				Environment.GetEnvironmentVariable(WindowsEnvironment.WindowsDirectoryVariable).Should().Be(resolved);
 
-			// The whole point of the fix: WPF can now build the fonts URI without throwing.
-			var buildFontsUri = () => new Uri(resolved + FontsSuffix, UriKind.Absolute);
-			buildFontsUri.Should().NotThrow();
-		});
+				// The whole point of the fix: WPF can now build the fonts URI without throwing.
+				var buildFontsUri = () => new Uri(resolved + FontsSuffix, UriKind.Absolute);
+				buildFontsUri.Should().NotThrow();
+			}
+		);
 	}
 
 	[Fact]
@@ -51,15 +52,16 @@ public sealed class WindowsEnvironmentTests
 	{
 		const string existing = @"C:\Windows";
 
-		WithWindir(existing, () =>
-		{
-			var resolved = WindowsEnvironment.EnsureWindowsDirectory();
+		WithWindir(
+			existing,
+			() =>
+			{
+				var resolved = WindowsEnvironment.EnsureWindowsDirectory();
 
-			resolved.Should().Be(existing);
-			Environment.GetEnvironmentVariable(WindowsEnvironment.WindowsDirectoryVariable)
-				.Should()
-				.Be(existing);
-		});
+				resolved.Should().Be(existing);
+				Environment.GetEnvironmentVariable(WindowsEnvironment.WindowsDirectoryVariable).Should().Be(existing);
+			}
+		);
 	}
 
 	/// <summary>
@@ -69,14 +71,17 @@ public sealed class WindowsEnvironmentTests
 	[Fact]
 	public void WpfFontSubsystemInitializesAfterWindirIsRestored()
 	{
-		WithWindir(string.Empty, () =>
-		{
-			WindowsEnvironment.EnsureWindowsDirectory();
+		WithWindir(
+			string.Empty,
+			() =>
+			{
+				WindowsEnvironment.EnsureWindowsDirectory();
 
-			var failure = TouchWpfFontSubsystem();
+				var failure = TouchWpfFontSubsystem();
 
-			failure.Should().BeNull("WPF font initialization must not crash once windir is restored");
-		});
+				failure.Should().BeNull("WPF font initialization must not crash once windir is restored");
+			}
+		);
 	}
 
 	/// <summary>


### PR DESCRIPTION
## Summary

Fixes #299.

BrowserPicker crashed during WPF startup with `System.Windows.Markup.XamlParseException` wrapping a `UriFormatException` thrown inside `MS.Internal.FontCache.Util`. This happens when BrowserPicker is launched from a host that passes a **stripped environment block missing the `windir` variable** — reported with the Codex desktop app's Azure DevOps MCP authentication flow.

### Root cause

WPF's font subsystem builds the Windows Fonts path as `Environment.GetEnvironmentVariable("windir") + "\Fonts\"` and then `new Uri(..., UriKind.Absolute)`. When `windir` is missing/empty the string becomes `\Fonts\`, which is not a valid absolute URI, so WPF throws during static initialization — before any window or URL-routing logic runs. The reporter's suggested `ThemeMode` workaround does not address this; that code runs later in `OnStartup`, after the crash point.

### Fix

Restore `windir` at the very start of `Program.Main`, before any WPF type initializes, from `SystemRoot` and finally the OS-resolved Windows folder (`Environment.SpecialFolder.Windows`, which does not depend on environment variables). Logic lives in a small, testable `BrowserPicker.Common.WindowsEnvironment.EnsureWindowsDirectory()` helper.

## Test plan

Added `WindowsEnvironmentTests` (in a non-parallel collection, since they mutate the process `windir`):

- [x] Root cause: with `windir` empty, WPF's exact `new Uri(windir + "\Fonts\", UriKind.Absolute)` throws `UriFormatException`.
- [x] Fix restores a value that makes the fonts URI valid.
- [x] An existing `windir` is left untouched.
- [x] End-to-end: clear `windir`, apply the fix, then initialize the WPF font subsystem (`FontFamily` / `SystemFonts`) on an STA thread and assert no crash.

Validated the end-to-end test is meaningful by temporarily confirming the same WPF touch crashes with `windir` cleared and no fix applied (then removed that scratch test). Full suite: 26/26 passing locally on Windows.
