### PR TITLE
Make application log UI theme-aware (#305)

### DIFF
--- a/src/BrowserPicker.UI/App.xaml.cs
+++ b/src/BrowserPicker.UI/App.xaml.cs
@@ -37,6 +37,9 @@ public partial class App
 	public const string UrlBarForegroundBrushKey = "UrlBarForegroundBrush";
 	public const string UrlBarBorderBrushKey = "UrlBarBorderBrush";
 
+	/// <summary>Highlight color for injected values in application log messages; needs contrast on both themes.</summary>
+	public const string LogValueHighlightBrushKey = "LogValueHighlightBrush";
+
 	private class InvalidUTF8Patch : EncodingProvider
 	{
 		public override Encoding? GetEncoding(int codepage)
@@ -185,6 +188,8 @@ public partial class App
 			d[UrlBarBackgroundBrushKey] = new SolidColorBrush(Colors.White);
 			d[UrlBarForegroundBrushKey] = new SolidColorBrush(Color.FromRgb(0x1A, 0x1A, 0x1A));
 			d[UrlBarBorderBrushKey] = new SolidColorBrush(Color.FromRgb(0xC8, 0xC8, 0xC8));
+			// Darker amber so injected log values stay readable on the light gray panel.
+			d[LogValueHighlightBrushKey] = new SolidColorBrush(Color.FromRgb(0xB4, 0x53, 0x09));
 		}
 		else
 		{
@@ -196,6 +201,8 @@ public partial class App
 			d[UrlBarBackgroundBrushKey] = new SolidColorBrush(Colors.White);
 			d[UrlBarForegroundBrushKey] = new SolidColorBrush(Color.FromRgb(0x1A, 0x1A, 0x1A));
 			d[UrlBarBorderBrushKey] = new SolidColorBrush(Color.FromRgb(0xB0, 0xB0, 0xB0));
+			// Soft gold reads well on the dark gray panel.
+			d[LogValueHighlightBrushKey] = new SolidColorBrush(Color.FromRgb(0xF5, 0xD0, 0x7A));
 		}
 		return d;
 	}

--- a/src/BrowserPicker.UI/TextBlockInlineSegments.cs
+++ b/src/BrowserPicker.UI/TextBlockInlineSegments.cs
@@ -2,7 +2,6 @@
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Documents;
-using System.Windows.Media;
 using BrowserPicker.Common;
 
 namespace BrowserPicker.UI;
@@ -45,7 +44,7 @@ public static class TextBlockInlineSegments
 			var run = new Run(segment.Text);
 			if (segment.IsValue)
 			{
-				run.Foreground = new SolidColorBrush(Color.FromRgb(0xF5, 0xD0, 0x7A));
+				run.SetResourceReference(TextElement.ForegroundProperty, App.LogValueHighlightBrushKey);
 				run.FontWeight = FontWeights.SemiBold;
 			}
 

--- a/src/BrowserPicker.UI/Views/Configuration.xaml
+++ b/src/BrowserPicker.UI/Views/Configuration.xaml
@@ -832,7 +832,12 @@
 									<StackPanel Margin="12,10" VerticalAlignment="Center" Orientation="Horizontal">
 										<TextBlock VerticalAlignment="Center" FontWeight="SemiBold" Foreground="{DynamicResource {x:Static ui:App.ContentForegroundBrushKey}}" Text="Application log" />
 										<TextBlock Text="  " />
-										<TextBlock VerticalAlignment="Center" FontSize="11" Opacity="0.6" Foreground="{DynamicResource {x:Static ui:App.ContentForegroundBrushKey}}" Text="{Binding ApplicationLogStatus}" />
+										<TextBlock
+											VerticalAlignment="Center"
+											FontSize="11"
+											Foreground="{DynamicResource {x:Static ui:App.ContentForegroundBrushKey}}"
+											Opacity="0.6"
+											Text="{Binding ApplicationLogStatus}" />
 									</StackPanel>
 									<Border
 										Grid.Column="1"
@@ -847,87 +852,87 @@
 							</Border>
 							<Border Grid.Row="1" BorderBrush="#22808080" BorderThickness="0,0,0,1">
 								<Grid>
-								<Grid.ColumnDefinitions>
-									<ColumnDefinition Width="Auto" />
-									<ColumnDefinition Width="Auto" />
-									<ColumnDefinition Width="Auto" />
-									<ColumnDefinition Width="*" />
-								</Grid.ColumnDefinitions>
-								<TextBlock
-									Margin="12,10,8,10"
-									VerticalAlignment="Center"
-									FontSize="11"
-									Opacity="0.6"
-									Foreground="{DynamicResource {x:Static ui:App.ContentForegroundBrushKey}}"
-									Text="Level" />
-								<ComboBox
-									Grid.Column="1"
-									MinWidth="150"
-									MinHeight="32"
-									Margin="0,8,12,8"
-									VerticalAlignment="Center"
-									VerticalContentAlignment="Center"
-									DisplayMemberPath="Label"
-									ItemsSource="{x:Static viewModels:ApplicationLogLevelOptions.All}"
-									SelectedItem="{Binding SelectedApplicationLogLevelOption}" />
-								<TextBlock
-									Grid.Column="2"
-									Margin="0,10,8,10"
-									VerticalAlignment="Center"
-									FontSize="11"
-									Opacity="0.6"
-									Foreground="{DynamicResource {x:Static ui:App.ContentForegroundBrushKey}}"
-									Text="Filter" />
-								<Grid Grid.Column="3" Margin="0,8,12,8">
-									<TextBox
-										Padding="8,4,26,4"
-										Background="{DynamicResource {x:Static ui:App.UrlBarBackgroundBrushKey}}"
-										BorderBrush="{DynamicResource {x:Static ui:App.UrlBarBorderBrushKey}}"
-										CaretBrush="#F59E0B"
-										Foreground="{DynamicResource {x:Static ui:App.UrlBarForegroundBrushKey}}"
-										Text="{Binding ApplicationLogFilter, UpdateSourceTrigger=PropertyChanged}"
-										ToolTip="Filter on timestamp, level, context, event, and message." />
+									<Grid.ColumnDefinitions>
+										<ColumnDefinition Width="Auto" />
+										<ColumnDefinition Width="Auto" />
+										<ColumnDefinition Width="Auto" />
+										<ColumnDefinition Width="*" />
+									</Grid.ColumnDefinitions>
 									<TextBlock
-										Margin="10,0,28,0"
+										Margin="12,10,8,10"
 										VerticalAlignment="Center"
-										Foreground="#64748B"
-										IsHitTestVisible="False"
-										Text="Filter timestamp, level, context, event, or message">
-										<TextBlock.Style>
-											<Style TargetType="TextBlock">
-												<Setter Property="Visibility" Value="Collapsed" />
-												<Style.Triggers>
-													<DataTrigger Binding="{Binding HasApplicationLogFilter}" Value="False">
-														<Setter Property="Visibility" Value="Visible" />
-													</DataTrigger>
-												</Style.Triggers>
-											</Style>
-										</TextBlock.Style>
-									</TextBlock>
-									<Button
-										Width="18"
-										Height="18"
-										Margin="0,0,6,0"
-										Padding="0"
-										HorizontalAlignment="Right"
+										FontSize="11"
+										Foreground="{DynamicResource {x:Static ui:App.ContentForegroundBrushKey}}"
+										Opacity="0.6"
+										Text="Level" />
+									<ComboBox
+										Grid.Column="1"
+										MinWidth="150"
+										MinHeight="32"
+										Margin="0,8,12,8"
 										VerticalAlignment="Center"
-										Background="#33808080"
-										BorderBrush="#475569"
-										Command="{Binding ClearApplicationLogFilter}"
-										Content="×"
-										Foreground="{DynamicResource {x:Static ui:App.UrlBarForegroundBrushKey}}">
-										<Button.Style>
-											<Style TargetType="Button">
-												<Setter Property="Visibility" Value="Collapsed" />
-												<Style.Triggers>
-													<DataTrigger Binding="{Binding HasApplicationLogFilter}" Value="True">
-														<Setter Property="Visibility" Value="Visible" />
-													</DataTrigger>
-												</Style.Triggers>
-											</Style>
-										</Button.Style>
-									</Button>
-								</Grid>
+										VerticalContentAlignment="Center"
+										DisplayMemberPath="Label"
+										ItemsSource="{x:Static viewModels:ApplicationLogLevelOptions.All}"
+										SelectedItem="{Binding SelectedApplicationLogLevelOption}" />
+									<TextBlock
+										Grid.Column="2"
+										Margin="0,10,8,10"
+										VerticalAlignment="Center"
+										FontSize="11"
+										Foreground="{DynamicResource {x:Static ui:App.ContentForegroundBrushKey}}"
+										Opacity="0.6"
+										Text="Filter" />
+									<Grid Grid.Column="3" Margin="0,8,12,8">
+										<TextBox
+											Padding="8,4,26,4"
+											Background="{DynamicResource {x:Static ui:App.UrlBarBackgroundBrushKey}}"
+											BorderBrush="{DynamicResource {x:Static ui:App.UrlBarBorderBrushKey}}"
+											CaretBrush="#F59E0B"
+											Foreground="{DynamicResource {x:Static ui:App.UrlBarForegroundBrushKey}}"
+											Text="{Binding ApplicationLogFilter, UpdateSourceTrigger=PropertyChanged}"
+											ToolTip="Filter on timestamp, level, context, event, and message." />
+										<TextBlock
+											Margin="10,0,28,0"
+											VerticalAlignment="Center"
+											Foreground="#64748B"
+											IsHitTestVisible="False"
+											Text="Filter timestamp, level, context, event, or message">
+											<TextBlock.Style>
+												<Style TargetType="TextBlock">
+													<Setter Property="Visibility" Value="Collapsed" />
+													<Style.Triggers>
+														<DataTrigger Binding="{Binding HasApplicationLogFilter}" Value="False">
+															<Setter Property="Visibility" Value="Visible" />
+														</DataTrigger>
+													</Style.Triggers>
+												</Style>
+											</TextBlock.Style>
+										</TextBlock>
+										<Button
+											Width="18"
+											Height="18"
+											Margin="0,0,6,0"
+											Padding="0"
+											HorizontalAlignment="Right"
+											VerticalAlignment="Center"
+											Background="#33808080"
+											BorderBrush="#475569"
+											Command="{Binding ClearApplicationLogFilter}"
+											Content="×"
+											Foreground="{DynamicResource {x:Static ui:App.UrlBarForegroundBrushKey}}">
+											<Button.Style>
+												<Style TargetType="Button">
+													<Setter Property="Visibility" Value="Collapsed" />
+													<Style.Triggers>
+														<DataTrigger Binding="{Binding HasApplicationLogFilter}" Value="True">
+															<Setter Property="Visibility" Value="Visible" />
+														</DataTrigger>
+													</Style.Triggers>
+												</Style>
+											</Button.Style>
+										</Button>
+									</Grid>
 								</Grid>
 							</Border>
 							<Grid Grid.Row="2" Grid.IsSharedSizeScope="True">
@@ -969,8 +974,8 @@
 																VerticalAlignment="Center"
 																FontFamily="Cascadia Mono,Consolas"
 																FontSize="12"
-																Opacity="0.6"
 																Foreground="{DynamicResource {x:Static ui:App.ContentForegroundBrushKey}}"
+																Opacity="0.6"
 																Text="{Binding TimestampDisplay}" />
 															<Border Margin="0,0,10,0" Padding="8,2" VerticalAlignment="Center" CornerRadius="999">
 																<Border.Style>
@@ -1005,21 +1010,21 @@
 																	Foreground="White"
 																	Text="{Binding LevelDisplay}" />
 															</Border>
+															<TextBlock
+																VerticalAlignment="Center"
+																FontSize="12"
+																Foreground="#3B82F6"
+																Text="{Binding CategoryDisplay}"
+																TextTrimming="CharacterEllipsis" />
+														</StackPanel>
 														<TextBlock
-															VerticalAlignment="Center"
-															FontSize="12"
-															Foreground="#3B82F6"
-															Text="{Binding CategoryDisplay}"
+															Margin="0,4,0,0"
+															FontFamily="Cascadia Mono,Consolas"
+															FontSize="11"
+															Foreground="{DynamicResource {x:Static ui:App.ContentForegroundBrushKey}}"
+															Opacity="0.6"
+															Text="{Binding EventDisplay}"
 															TextTrimming="CharacterEllipsis" />
-													</StackPanel>
-													<TextBlock
-														Margin="0,4,0,0"
-														FontFamily="Cascadia Mono,Consolas"
-														FontSize="11"
-														Opacity="0.6"
-														Foreground="{DynamicResource {x:Static ui:App.ContentForegroundBrushKey}}"
-														Text="{Binding EventDisplay}"
-														TextTrimming="CharacterEllipsis" />
 													</StackPanel>
 													<TextBlock
 														Grid.Column="1"
@@ -1030,20 +1035,20 @@
 														FontSize="12"
 														TextWrapping="Wrap">
 														<TextBlock.Style>
-														<Style TargetType="TextBlock">
-															<Setter Property="Foreground" Value="{DynamicResource {x:Static ui:App.ContentForegroundBrushKey}}" />
-															<Style.Triggers>
-																<DataTrigger Binding="{Binding Level}" Value="{x:Static logging:LogLevel.Warning}">
-																	<Setter Property="Foreground" Value="#D97706" />
-																</DataTrigger>
-																<DataTrigger Binding="{Binding Level}" Value="{x:Static logging:LogLevel.Error}">
-																	<Setter Property="Foreground" Value="#DC2626" />
-																</DataTrigger>
-																<DataTrigger Binding="{Binding Level}" Value="{x:Static logging:LogLevel.Critical}">
-																	<Setter Property="Foreground" Value="#7C3AED" />
-																</DataTrigger>
-															</Style.Triggers>
-														</Style>
+															<Style TargetType="TextBlock">
+																<Setter Property="Foreground" Value="{DynamicResource {x:Static ui:App.ContentForegroundBrushKey}}" />
+																<Style.Triggers>
+																	<DataTrigger Binding="{Binding Level}" Value="{x:Static logging:LogLevel.Warning}">
+																		<Setter Property="Foreground" Value="#D97706" />
+																	</DataTrigger>
+																	<DataTrigger Binding="{Binding Level}" Value="{x:Static logging:LogLevel.Error}">
+																		<Setter Property="Foreground" Value="#DC2626" />
+																	</DataTrigger>
+																	<DataTrigger Binding="{Binding Level}" Value="{x:Static logging:LogLevel.Critical}">
+																		<Setter Property="Foreground" Value="#7C3AED" />
+																	</DataTrigger>
+																</Style.Triggers>
+															</Style>
 														</TextBlock.Style>
 													</TextBlock>
 												</Grid>
@@ -1055,8 +1060,8 @@
 									HorizontalAlignment="Center"
 									VerticalAlignment="Center"
 									FontStyle="Italic"
-									Opacity="0.6"
 									Foreground="{DynamicResource {x:Static ui:App.ContentForegroundBrushKey}}"
+									Opacity="0.6"
 									Text="Logs will appear here as Browser Picker runs.">
 									<TextBlock.Style>
 										<Style TargetType="TextBlock">

--- a/src/BrowserPicker.UI/Views/Configuration.xaml
+++ b/src/BrowserPicker.UI/Views/Configuration.xaml
@@ -816,34 +816,37 @@
 							</WrapPanel>
 						</Grid>
 					</Border>
-					<Border Grid.Row="1" Background="#111827" SnapsToDevicePixels="True">
+					<Border Grid.Row="1" Background="{DynamicResource {x:Static ui:App.ContentBackgroundBrushKey}}" SnapsToDevicePixels="True">
 						<Grid Margin="0">
 							<Grid.RowDefinitions>
 								<RowDefinition Height="Auto" />
 								<RowDefinition Height="Auto" />
 								<RowDefinition Height="*" />
 							</Grid.RowDefinitions>
-							<Grid Background="#1F2937">
-								<Grid.ColumnDefinitions>
-									<ColumnDefinition Width="*" />
-									<ColumnDefinition Width="Auto" />
-								</Grid.ColumnDefinitions>
-								<StackPanel Margin="12,10" VerticalAlignment="Center" Orientation="Horizontal">
-									<TextBlock FontWeight="SemiBold" Foreground="#F9FAFB" Text="Application log" />
-									<TextBlock Text="  " />
-									<TextBlock FontSize="11" Foreground="#9CA3AF" Text="{Binding ApplicationLogStatus}" />
-								</StackPanel>
-								<Border
-									Grid.Column="1"
-									Margin="8,10,12,10"
-									Padding="8,2"
-									VerticalAlignment="Center"
-									Background="#374151"
-									CornerRadius="999">
-									<TextBlock FontSize="11" Foreground="#FDE68A" Text="{Binding ApplicationLogEntryCount, StringFormat={}{0} lines}" />
-								</Border>
-							</Grid>
-							<Grid Grid.Row="1" Background="#162132">
+							<Border BorderBrush="#22808080" BorderThickness="0,0,0,1">
+								<Grid>
+									<Grid.ColumnDefinitions>
+										<ColumnDefinition Width="*" />
+										<ColumnDefinition Width="Auto" />
+									</Grid.ColumnDefinitions>
+									<StackPanel Margin="12,10" VerticalAlignment="Center" Orientation="Horizontal">
+										<TextBlock VerticalAlignment="Center" FontWeight="SemiBold" Foreground="{DynamicResource {x:Static ui:App.ContentForegroundBrushKey}}" Text="Application log" />
+										<TextBlock Text="  " />
+										<TextBlock VerticalAlignment="Center" FontSize="11" Opacity="0.6" Foreground="{DynamicResource {x:Static ui:App.ContentForegroundBrushKey}}" Text="{Binding ApplicationLogStatus}" />
+									</StackPanel>
+									<Border
+										Grid.Column="1"
+										Margin="8,10,12,10"
+										Padding="8,2"
+										VerticalAlignment="Center"
+										Background="#33808080"
+										CornerRadius="999">
+										<TextBlock FontSize="11" Foreground="{DynamicResource {x:Static ui:App.ContentForegroundBrushKey}}" Text="{Binding ApplicationLogEntryCount, StringFormat={}{0} lines}" />
+									</Border>
+								</Grid>
+							</Border>
+							<Border Grid.Row="1" BorderBrush="#22808080" BorderThickness="0,0,0,1">
+								<Grid>
 								<Grid.ColumnDefinitions>
 									<ColumnDefinition Width="Auto" />
 									<ColumnDefinition Width="Auto" />
@@ -854,7 +857,8 @@
 									Margin="12,10,8,10"
 									VerticalAlignment="Center"
 									FontSize="11"
-									Foreground="#94A3B8"
+									Opacity="0.6"
+									Foreground="{DynamicResource {x:Static ui:App.ContentForegroundBrushKey}}"
 									Text="Level" />
 								<ComboBox
 									Grid.Column="1"
@@ -871,15 +875,16 @@
 									Margin="0,10,8,10"
 									VerticalAlignment="Center"
 									FontSize="11"
-									Foreground="#94A3B8"
+									Opacity="0.6"
+									Foreground="{DynamicResource {x:Static ui:App.ContentForegroundBrushKey}}"
 									Text="Filter" />
 								<Grid Grid.Column="3" Margin="0,8,12,8">
 									<TextBox
 										Padding="8,4,26,4"
-										Background="#0F172A"
-										BorderBrush="#334155"
+										Background="{DynamicResource {x:Static ui:App.UrlBarBackgroundBrushKey}}"
+										BorderBrush="{DynamicResource {x:Static ui:App.UrlBarBorderBrushKey}}"
 										CaretBrush="#F59E0B"
-										Foreground="#E5E7EB"
+										Foreground="{DynamicResource {x:Static ui:App.UrlBarForegroundBrushKey}}"
 										Text="{Binding ApplicationLogFilter, UpdateSourceTrigger=PropertyChanged}"
 										ToolTip="Filter on timestamp, level, context, event, and message." />
 									<TextBlock
@@ -906,11 +911,11 @@
 										Padding="0"
 										HorizontalAlignment="Right"
 										VerticalAlignment="Center"
-										Background="#334155"
+										Background="#33808080"
 										BorderBrush="#475569"
 										Command="{Binding ClearApplicationLogFilter}"
 										Content="×"
-										Foreground="#E5E7EB">
+										Foreground="{DynamicResource {x:Static ui:App.UrlBarForegroundBrushKey}}">
 										<Button.Style>
 											<Style TargetType="Button">
 												<Setter Property="Visibility" Value="Collapsed" />
@@ -923,14 +928,15 @@
 										</Button.Style>
 									</Button>
 								</Grid>
-							</Grid>
+								</Grid>
+							</Border>
 							<Grid Grid.Row="2" Grid.IsSharedSizeScope="True">
 								<ListBox
 									Padding="0"
 									ui:AutoTailListBoxBehavior.IsEnabled="True"
-									Background="#111827"
+									Background="{DynamicResource {x:Static ui:App.ContentBackgroundBrushKey}}"
 									BorderThickness="0"
-									Foreground="#E5E7EB"
+									Foreground="{DynamicResource {x:Static ui:App.ContentForegroundBrushKey}}"
 									ItemsSource="{Binding FilteredApplicationLogEntries}"
 									ScrollViewer.CanContentScroll="True"
 									ScrollViewer.HorizontalScrollBarVisibility="Disabled"
@@ -950,7 +956,7 @@
 									</ListBox.ItemContainerStyle>
 									<ListBox.ItemTemplate>
 										<DataTemplate DataType="{x:Type common:InMemoryLogEntry}">
-											<Border Padding="12,8" BorderBrush="#1F2937" BorderThickness="0,0,0,1">
+											<Border Padding="12,8" BorderBrush="#22808080" BorderThickness="0,0,0,1">
 												<Grid>
 													<Grid.ColumnDefinitions>
 														<ColumnDefinition Width="Auto" MinWidth="240" MaxWidth="360" SharedSizeGroup="LogMetadataColumn" />
@@ -963,7 +969,8 @@
 																VerticalAlignment="Center"
 																FontFamily="Cascadia Mono,Consolas"
 																FontSize="12"
-																Foreground="#94A3B8"
+																Opacity="0.6"
+																Foreground="{DynamicResource {x:Static ui:App.ContentForegroundBrushKey}}"
 																Text="{Binding TimestampDisplay}" />
 															<Border Margin="0,0,10,0" Padding="8,2" VerticalAlignment="Center" CornerRadius="999">
 																<Border.Style>
@@ -998,20 +1005,21 @@
 																	Foreground="White"
 																	Text="{Binding LevelDisplay}" />
 															</Border>
-															<TextBlock
-																VerticalAlignment="Center"
-																FontSize="12"
-																Foreground="#60A5FA"
-																Text="{Binding CategoryDisplay}"
-																TextTrimming="CharacterEllipsis" />
-														</StackPanel>
 														<TextBlock
-															Margin="0,4,0,0"
-															FontFamily="Cascadia Mono,Consolas"
-															FontSize="11"
-															Foreground="#94A3B8"
-															Text="{Binding EventDisplay}"
+															VerticalAlignment="Center"
+															FontSize="12"
+															Foreground="#3B82F6"
+															Text="{Binding CategoryDisplay}"
 															TextTrimming="CharacterEllipsis" />
+													</StackPanel>
+													<TextBlock
+														Margin="0,4,0,0"
+														FontFamily="Cascadia Mono,Consolas"
+														FontSize="11"
+														Opacity="0.6"
+														Foreground="{DynamicResource {x:Static ui:App.ContentForegroundBrushKey}}"
+														Text="{Binding EventDisplay}"
+														TextTrimming="CharacterEllipsis" />
 													</StackPanel>
 													<TextBlock
 														Grid.Column="1"
@@ -1022,20 +1030,20 @@
 														FontSize="12"
 														TextWrapping="Wrap">
 														<TextBlock.Style>
-															<Style TargetType="TextBlock">
-																<Setter Property="Foreground" Value="#E5E7EB" />
-																<Style.Triggers>
-																	<DataTrigger Binding="{Binding Level}" Value="{x:Static logging:LogLevel.Warning}">
-																		<Setter Property="Foreground" Value="#FDE68A" />
-																	</DataTrigger>
-																	<DataTrigger Binding="{Binding Level}" Value="{x:Static logging:LogLevel.Error}">
-																		<Setter Property="Foreground" Value="#FCA5A5" />
-																	</DataTrigger>
-																	<DataTrigger Binding="{Binding Level}" Value="{x:Static logging:LogLevel.Critical}">
-																		<Setter Property="Foreground" Value="#DDD6FE" />
-																	</DataTrigger>
-																</Style.Triggers>
-															</Style>
+														<Style TargetType="TextBlock">
+															<Setter Property="Foreground" Value="{DynamicResource {x:Static ui:App.ContentForegroundBrushKey}}" />
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding Level}" Value="{x:Static logging:LogLevel.Warning}">
+																	<Setter Property="Foreground" Value="#D97706" />
+																</DataTrigger>
+																<DataTrigger Binding="{Binding Level}" Value="{x:Static logging:LogLevel.Error}">
+																	<Setter Property="Foreground" Value="#DC2626" />
+																</DataTrigger>
+																<DataTrigger Binding="{Binding Level}" Value="{x:Static logging:LogLevel.Critical}">
+																	<Setter Property="Foreground" Value="#7C3AED" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
 														</TextBlock.Style>
 													</TextBlock>
 												</Grid>
@@ -1047,7 +1055,8 @@
 									HorizontalAlignment="Center"
 									VerticalAlignment="Center"
 									FontStyle="Italic"
-									Foreground="#94A3B8"
+									Opacity="0.6"
+									Foreground="{DynamicResource {x:Static ui:App.ContentForegroundBrushKey}}"
 									Text="Logs will appear here as Browser Picker runs.">
 									<TextBlock.Style>
 										<Style TargetType="TextBlock">


### PR DESCRIPTION
## Summary

Fixes #305 — the Feedback tab's **Application log** panel was the only part of the settings dialog that hardcoded a dark GitHub-style palette regardless of theme, so it looked "wildly out of place" (a dark slab dropped into a light dialog, and mismatched greys in dark mode).

- Surfaces (panel, header band, filter bar, log list) now use the same dynamic theme brushes (`ContentBackgroundBrush` / `ContentForegroundBrush`) as the rest of the dialog, with muted text via `Opacity`.
- The filter text box now uses the app's input brushes (`UrlBar*`), matching the URL bar elsewhere.
- Header/filter separators use a subtle theme-neutral hairline instead of hardcoded dark bands.
- Severity message tints were moved from pastels (legible only on dark) to mid-tones that read on both light and dark.
- Header title and status text are vertically centered so the smaller status line aligns with the title.

Preserved the panel's character: colored severity **level badges**, **monospace** log text, and category coloring.

Change is confined to `Configuration.xaml`; no new theme resources required.

## Test plan

- [x] `dotnet build src/BrowserPicker.UI/BrowserPicker.UI.csproj -p:Version=1.0.0 -p:Platform=x64` succeeds
- [x] Verified visually in both light and dark theme
- [x] Confirm severity colors (warning/error/critical) remain legible on both backgrounds
