### PR TITLE
Fix browser profile UI issues (#304)

### DIFF
--- a/schemas/browserpicker-settings.schema.json
+++ b/schemas/browserpicker-settings.schema.json
@@ -111,6 +111,9 @@
     "ProfileDisplayMode": {
       "$ref": "#/definitions/ProfileDisplayMode"
     },
+    "PersistProfileExpansion": {
+      "type": "boolean"
+    },
     "SortBy": {
       "$ref": "#/definitions/SortOrder"
     }
@@ -186,6 +189,9 @@
               "items": {
                 "$ref": "#/definitions/BrowserProfile"
               }
+            },
+            "ProfilesExpanded": {
+              "type": "boolean"
             }
           }
         }

--- a/src/BrowserPicker.Common/BrowserModel.cs
+++ b/src/BrowserPicker.Common/BrowserModel.cs
@@ -203,7 +203,22 @@ public sealed class BrowserModel : ModelBase
 	/// <summary>
 	/// Profiles available for this browser (e.g. Chrome profiles, Firefox profiles/containers).
 	/// </summary>
-	public List<BrowserProfile> Profiles { get; } = [];
+	/// <remarks>
+	/// <see cref="JsonIncludeAttribute"/> is required so System.Text.Json populates this collection on load;
+	/// without it the get-only property is ignored and persisted profiles are lost between launches.
+	/// </remarks>
+	[JsonInclude]
+	public List<BrowserProfile> Profiles { get; private set; } = [];
+
+	/// <summary>
+	/// Whether the profile sub-list is expanded in the grouped picker view. Persisted so the user's
+	/// choice survives across picker launches (each link opens a fresh process).
+	/// </summary>
+	public bool ProfilesExpanded
+	{
+		get => profiles_expanded;
+		set => SetProperty(ref profiles_expanded, value);
+	}
 
 	private int usage;
 	private bool disabled;
@@ -220,4 +235,5 @@ public sealed class BrowserModel : ModelBase
 	private bool manual_override;
 	private string custom_key = string.Empty;
 	private bool containers_enabled;
+	private bool profiles_expanded;
 }

--- a/src/BrowserPicker.Common/BrowserProfile.cs
+++ b/src/BrowserPicker.Common/BrowserProfile.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.Text.Json.Serialization;
 using BrowserPicker.Common.Framework;
 using JetBrains.Annotations;
 
@@ -18,6 +19,11 @@ public sealed class BrowserProfile(string id, string name, string? commandArgs, 
 	/// <summary>
 	/// Stable identifier for this profile (e.g. "Default", "Profile 1", "container:Work").
 	/// </summary>
+	/// <remarks>
+	/// <see cref="JsonIncludeAttribute"/> lets System.Text.Json restore the id via the private setter
+	/// when deserializing persisted profiles (the parameterless constructor leaves it empty otherwise).
+	/// </remarks>
+	[JsonInclude]
 	public string Id
 	{
 		get => id;
@@ -64,12 +70,13 @@ public sealed class BrowserProfile(string id, string name, string? commandArgs, 
 	}
 
 	/// <summary>
-	/// When true, this profile is hidden from the picker UI.
+	/// When true, this profile is hidden from the picker UI. Toggled by the user in configuration
+	/// to filter out unwanted profiles; persisted so the choice survives across launches.
 	/// </summary>
 	public bool Disabled
 	{
 		get => disabled;
-		private set => _ = SetProperty(ref disabled, value);
+		set => SetProperty(ref disabled, value);
 	}
 
 	/// <summary>

--- a/src/BrowserPicker.Common/IApplicationSettings.cs
+++ b/src/BrowserPicker.Common/IApplicationSettings.cs
@@ -129,4 +129,10 @@ public interface IApplicationSettings : ISecuritySettings
 	/// How browser profiles are displayed in the picker UI: grouped under their browser or as flat top-level entries.
 	/// </summary>
 	ProfileDisplayMode ProfileDisplayMode { get; set; }
+
+	/// <summary>
+	/// When true (default), a browser's profile sub-list keeps its expanded/collapsed state between picker launches.
+	/// When false, profile groups always start collapsed. Only applies to grouped profile display.
+	/// </summary>
+	bool PersistProfileExpansion { get; set; }
 }

--- a/src/BrowserPicker.Common/SerializableSettings.cs
+++ b/src/BrowserPicker.Common/SerializableSettings.cs
@@ -51,6 +51,7 @@ public sealed class SerializableSettings : IApplicationSettings
 		FontSize = applicationSettings.FontSize;
 		ThemeMode = applicationSettings.ThemeMode;
 		ProfileDisplayMode = applicationSettings.ProfileDisplayMode;
+		PersistProfileExpansion = applicationSettings.PersistProfileExpansion;
 	}
 
 	/// <summary>
@@ -149,6 +150,9 @@ public sealed class SerializableSettings : IApplicationSettings
 
 	/// <inheritdoc />
 	public ProfileDisplayMode ProfileDisplayMode { get; set; }
+
+	/// <inheritdoc />
+	public bool PersistProfileExpansion { get; set; } = true;
 
 	/// <summary>
 	/// How to sort the browser list: automatic (by usage), manual, or alphabetical.

--- a/src/BrowserPicker.UI/ViewModels/ApplicationViewModel.cs
+++ b/src/BrowserPicker.UI/ViewModels/ApplicationViewModel.cs
@@ -140,6 +140,11 @@ public sealed class ApplicationViewModel : ModelBase
 	/// <returns><see langword="true"/> when the main window should be shown; otherwise <see langword="false"/>.</returns>
 	public bool Initialize()
 	{
+		// Profile discovery runs as a background task that completes before the picker is shown.
+		// Rebuild the picker entries here so profiles discovered after construction appear, notably in
+		// flat display mode where the entry list is a flattened snapshot rather than a live binding.
+		RefreshDiscoveredProfiles();
+
 		if (Configuration.Settings.FirstTime)
 		{
 			Configuration.Welcome = true;
@@ -583,6 +588,21 @@ public sealed class ApplicationViewModel : ModelBase
 		{
 			Choices.Add(choice);
 		}
+		RebuildPickerChoices();
+	}
+
+	/// <summary>
+	/// Discards cached profile view models on every choice and rebuilds the picker entries, so profiles
+	/// found by asynchronous discovery after construction are reflected (important for flat display mode,
+	/// whose entry list is a one-time snapshot rather than a live binding).
+	/// </summary>
+	internal void RefreshDiscoveredProfiles()
+	{
+		foreach (var choice in Choices)
+		{
+			choice.InvalidateProfileCache();
+		}
+
 		RebuildPickerChoices();
 	}
 

--- a/src/BrowserPicker.UI/ViewModels/BrowserProfileViewModel.cs
+++ b/src/BrowserPicker.UI/ViewModels/BrowserProfileViewModel.cs
@@ -74,6 +74,38 @@ public sealed class BrowserProfileViewModel : ViewModelBase<BrowserProfile>
 	/// </summary>
 	public bool AltPressed => ParentBrowser.AltPressed;
 
+	/// <summary>
+	/// Whether this profile is hidden from the picker. Toggled by the user in configuration to filter
+	/// out unwanted profiles; setting it refreshes the parent browser's picker profile list.
+	/// </summary>
+	public bool Hidden
+	{
+		get => Model.Disabled;
+		set
+		{
+			if (Model.Disabled == value)
+			{
+				return;
+			}
+
+			Model.Disabled = value;
+			OnPropertyChanged();
+			OnPropertyChanged(nameof(VisibilityActionText));
+			ParentBrowser.OnProfileVisibilityChanged();
+		}
+	}
+
+	/// <summary>
+	/// Label for the show/hide toggle in configuration, reflecting the action that will be taken.
+	/// </summary>
+	public string VisibilityActionText => Model.Disabled ? "Hidden" : "Visible";
+
+	/// <summary>
+	/// Toggles whether this profile is shown in the picker.
+	/// </summary>
+	public DelegateCommand ToggleVisibility => toggle_visibility ??= new DelegateCommand(() => Hidden = !Hidden);
+
 	private DelegateCommand? select;
 	private DelegateCommand? select_privacy;
+	private DelegateCommand? toggle_visibility;
 }

--- a/src/BrowserPicker.UI/ViewModels/BrowserViewModel.cs
+++ b/src/BrowserPicker.UI/ViewModels/BrowserViewModel.cs
@@ -75,6 +75,10 @@ public sealed class BrowserViewModel : ViewModelBase<BrowserModel>
 				OnPropertyChanged(nameof(ShowNestedProfilesInPicker));
 				OnPropertyChanged(nameof(ShowNestedProfileSubtree));
 				break;
+			case nameof(IApplicationSettings.PersistProfileExpansion):
+				OnPropertyChanged(nameof(IsExpanded));
+				OnPropertyChanged(nameof(ShowNestedProfileSubtree));
+				break;
 		}
 	}
 
@@ -121,12 +125,42 @@ public sealed class BrowserViewModel : ViewModelBase<BrowserModel>
 	private void RefreshProfiles()
 	{
 		profile_view_models = null;
+		config_profile_view_models = null;
 		IsExpanded = false;
+		OnPropertyChanged(nameof(ProfileViewModels));
+		OnPropertyChanged(nameof(ConfigProfileViewModels));
+		OnPropertyChanged(nameof(HasProfiles));
+		OnPropertyChanged(nameof(HasAnyProfiles));
+		OnPropertyChanged(nameof(ShowNestedProfilesInPicker));
+		OnPropertyChanged(nameof(ShowNestedProfileSubtree));
+		parent_view_model.RebuildPickerChoices();
+	}
+
+	/// <summary>
+	/// Re-evaluates profile visibility after the user toggles a profile's hidden state in configuration,
+	/// keeping the picker's filtered profile list and choices in sync without discarding cached view models.
+	/// </summary>
+	internal void OnProfileVisibilityChanged()
+	{
+		profile_view_models = null;
 		OnPropertyChanged(nameof(ProfileViewModels));
 		OnPropertyChanged(nameof(HasProfiles));
 		OnPropertyChanged(nameof(ShowNestedProfilesInPicker));
 		OnPropertyChanged(nameof(ShowNestedProfileSubtree));
 		parent_view_model.RebuildPickerChoices();
+	}
+
+	/// <summary>
+	/// Discards the cached picker profile view models so they are rebuilt from the current model on next access.
+	/// Used after asynchronous discovery so newly found profiles appear (notably in flat display mode).
+	/// </summary>
+	internal void InvalidateProfileCache()
+	{
+		profile_view_models = null;
+		OnPropertyChanged(nameof(ProfileViewModels));
+		OnPropertyChanged(nameof(HasProfiles));
+		OnPropertyChanged(nameof(ShowNestedProfilesInPicker));
+		OnPropertyChanged(nameof(ShowNestedProfileSubtree));
 	}
 
 	/// <summary>
@@ -441,18 +475,34 @@ public sealed class BrowserViewModel : ViewModelBase<BrowserModel>
 	}
 
 	/// <summary>
-	/// Whether the profile sub-list is expanded in the picker UI (grouped mode).
+	/// Whether the profile sub-list is expanded in the picker UI (grouped mode). When
+	/// <see cref="IApplicationSettings.PersistProfileExpansion"/> is enabled the state is backed by
+	/// <see cref="BrowserModel.ProfilesExpanded"/> and persists across launches; otherwise it is held in
+	/// memory only, so profile groups always start collapsed.
 	/// </summary>
 	public bool IsExpanded
 	{
-		get => is_expanded;
+		get =>
+			parent_view_model.Configuration.Settings.PersistProfileExpansion
+				? Model.ProfilesExpanded
+				: is_expanded_transient;
 		set
 		{
-			if (!SetProperty(ref is_expanded, value))
+			if (IsExpanded == value)
 			{
 				return;
 			}
 
+			if (parent_view_model.Configuration.Settings.PersistProfileExpansion)
+			{
+				Model.ProfilesExpanded = value;
+			}
+			else
+			{
+				is_expanded_transient = value;
+			}
+
+			OnPropertyChanged();
 			OnPropertyChanged(nameof(ShowNestedProfileSubtree));
 		}
 	}
@@ -463,7 +513,7 @@ public sealed class BrowserViewModel : ViewModelBase<BrowserModel>
 	public DelegateCommand ExpandToggle => expand_toggle ??= new DelegateCommand(() => IsExpanded = !IsExpanded);
 
 	/// <summary>
-	/// Observable collection of profile view models for the picker UI.
+	/// Observable collection of profile view models for the picker UI (hidden profiles excluded).
 	/// Lazily populated on first access.
 	/// </summary>
 	public ObservableCollection<BrowserProfileViewModel> ProfileViewModels
@@ -477,10 +527,32 @@ public sealed class BrowserViewModel : ViewModelBase<BrowserModel>
 		}
 	}
 
-	private bool is_expanded;
+	/// <summary>
+	/// True when this browser has any discovered profiles, including ones the user has hidden.
+	/// Drives whether the per-profile visibility controls are shown in configuration.
+	/// </summary>
+	public bool HasAnyProfiles => Model.Profiles.Count > 0;
+
+	/// <summary>
+	/// Observable collection of profile view models for the configuration UI, including hidden profiles
+	/// so the user can toggle their visibility. Lazily populated on first access.
+	/// </summary>
+	public ObservableCollection<BrowserProfileViewModel> ConfigProfileViewModels
+	{
+		get
+		{
+			config_profile_view_models ??= new ObservableCollection<BrowserProfileViewModel>(
+				Model.Profiles.Select(p => new BrowserProfileViewModel(p, this))
+			);
+			return config_profile_view_models;
+		}
+	}
+
+	private bool is_expanded_transient;
 	private DelegateCommand? expand_toggle;
 	private DelegateCommand? open_extension_link;
 	private ObservableCollection<BrowserProfileViewModel>? profile_view_models;
+	private ObservableCollection<BrowserProfileViewModel>? config_profile_view_models;
 
 	/// <summary>
 	/// Determines if the browser can be launched with the specified privacy setting.

--- a/src/BrowserPicker.UI/ViewModels/ConfigurationViewModel.cs
+++ b/src/BrowserPicker.UI/ViewModels/ConfigurationViewModel.cs
@@ -156,6 +156,7 @@ public sealed class ConfigurationViewModel : ModelBase
 		public double FontSize { get; set; } = 14;
 		public Common.ThemeMode ThemeMode { get; set; } = Common.ThemeMode.System;
 		public ProfileDisplayMode ProfileDisplayMode { get; set; }
+		public bool PersistProfileExpansion { get; set; } = true;
 
 		public string[] UrlShorteners { get; set; } = [.. UrlHandler.DefaultUrlShorteners, "example.com"];
 

--- a/src/BrowserPicker.UI/ViewModels/FeedbackViewModel.cs
+++ b/src/BrowserPicker.UI/ViewModels/FeedbackViewModel.cs
@@ -643,6 +643,7 @@ public sealed class FeedbackViewModel : ModelBase
 		public double FontSize { get; set; } = 14;
 		public Common.ThemeMode ThemeMode { get; set; } = Common.ThemeMode.Dark;
 		public ProfileDisplayMode ProfileDisplayMode { get; set; }
+		public bool PersistProfileExpansion { get; set; } = true;
 		public bool UseFallbackDefault { get; set; } = true;
 		public string? DefaultBrowser { get; set; } = Firefox.Instance.Name;
 		public string BackupLog => "Copied configuration JSON to the clipboard.";

--- a/src/BrowserPicker.UI/Views/Configuration.xaml
+++ b/src/BrowserPicker.UI/Views/Configuration.xaml
@@ -251,94 +251,148 @@
 								</ItemsControl.ItemsPanel>
 								<ItemsControl.ItemTemplate>
 									<DataTemplate DataType="viewModels:BrowserViewModel">
-										<Grid>
-											<Grid.Style>
-												<Style>
-													<Setter Property="UIElement.Visibility" Value="Visible" />
+										<StackPanel>
+											<StackPanel.Style>
+												<Style TargetType="StackPanel">
+													<Setter Property="Visibility" Value="Visible" />
 													<Style.Triggers>
 														<DataTrigger Binding="{Binding Model.Removed}" Value="True">
-															<Setter Property="UIElement.Visibility" Value="Collapsed" />
+															<Setter Property="Visibility" Value="Collapsed" />
 														</DataTrigger>
 													</Style.Triggers>
 												</Style>
-											</Grid.Style>
-											<Grid.ColumnDefinitions>
-												<ColumnDefinition Width="Auto" />
-												<ColumnDefinition Width="*" />
-												<ColumnDefinition Width="Auto" />
-												<ColumnDefinition Width="Auto" />
-												<ColumnDefinition Width="Auto" />
-												<ColumnDefinition Width="Auto" />
-												<ColumnDefinition Width="Auto" />
-											</Grid.ColumnDefinitions>
-											<ContentPresenter
-												Width="40"
-												Height="40"
-												Margin="20,0,0,0"
-												Content="{Binding}"
-												ContentTemplate="{StaticResource BrowserIcon}" />
-											<TextBlock Grid.Column="1" Margin="10" FontSize="18" Text="{Binding Model.Name}" />
-											<Grid Grid.Column="2" VerticalAlignment="Center">
-												<Grid.Style>
-													<Style TargetType="Grid">
+											</StackPanel.Style>
+											<Grid>
+												<Grid.ColumnDefinitions>
+													<ColumnDefinition Width="Auto" />
+													<ColumnDefinition Width="*" />
+													<ColumnDefinition Width="Auto" />
+													<ColumnDefinition Width="Auto" />
+													<ColumnDefinition Width="Auto" />
+													<ColumnDefinition Width="Auto" />
+													<ColumnDefinition Width="Auto" />
+												</Grid.ColumnDefinitions>
+												<ContentPresenter
+													Width="40"
+													Height="40"
+													Margin="20,0,0,0"
+													Content="{Binding}"
+													ContentTemplate="{StaticResource BrowserIcon}" />
+												<TextBlock Grid.Column="1" Margin="10" FontSize="18" Text="{Binding Model.Name}" />
+												<Grid Grid.Column="2" VerticalAlignment="Center">
+													<Grid.Style>
+														<Style TargetType="Grid">
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding IsManuallyOrdered}" Value="False">
+																	<Setter Property="Visibility" Value="Collapsed" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</Grid.Style>
+													<Grid.RowDefinitions>
+														<RowDefinition Height="Auto" />
+														<RowDefinition Height="Auto" />
+													</Grid.RowDefinitions>
+													<TextBlock FontSize="10"><Hyperlink Command="{Binding MoveUp}" TextDecorations="None">🔼</Hyperlink></TextBlock>
+													<TextBlock Grid.Row="1" FontSize="10"><Hyperlink Command="{Binding MoveDown}" TextDecorations="None">🔽</Hyperlink></TextBlock>
+												</Grid>
+												<TextBlock Grid.Column="3" Margin="10" FontSize="16">
+													<Hyperlink Command="{Binding Disable}">
+														<TextBlock>
+															<TextBlock.Style>
+																<Style>
+																	<Setter Property="TextBlock.Foreground" Value="Green" />
+																	<Setter Property="TextBlock.Text" Value="Enabled" />
+																	<Setter Property="FrameworkElement.ToolTip" Value="Toggle whether this browser appears in the picker" />
+																	<Style.Triggers>
+																		<DataTrigger Binding="{Binding Model.Disabled}" Value="True">
+																			<Setter Property="TextBlock.Foreground" Value="OrangeRed" />
+																			<Setter Property="TextBlock.Text" Value="Disabled" />
+																		</DataTrigger>
+																	</Style.Triggers>
+																</Style>
+															</TextBlock.Style>
+														</TextBlock>
+													</Hyperlink>
+												</TextBlock>
+												<TextBlock Grid.Column="4" Margin="10" FontSize="16">
+													<Hyperlink Command="{Binding Edit}">
+														<TextBlock Foreground="CadetBlue" Text="Edit" ToolTip="Edit browser definition" />
+													</Hyperlink>
+												</TextBlock>
+												<TextBlock Grid.Column="5" Margin="10" FontSize="16">
+													<Hyperlink Command="{Binding Duplicate}">
+														<TextBlock Foreground="LightGreen" Text="+" ToolTip="Duplicate browser: create a new browser using this browser as a starting point" />
+													</Hyperlink>
+												</TextBlock>
+												<TextBlock Grid.Column="6" Margin="10" FontSize="16">
+													<TextBlock.Style>
+														<Style TargetType="TextBlock">
+															<Style.Triggers>
+																<DataTrigger Binding="{Binding CanRemove}" Value="False">
+																	<Setter Property="Visibility" Value="Hidden" />
+																</DataTrigger>
+															</Style.Triggers>
+														</Style>
+													</TextBlock.Style>
+													<Hyperlink Command="{Binding Remove}">
+														<TextBlock Foreground="Red" Text="X" ToolTip="Remove custom browser from list" />
+													</Hyperlink>
+												</TextBlock>
+											</Grid>
+											<ItemsControl Margin="70,0,20,10" d:ItemsSource="{Binding ConfigProfileViewModels}" ItemsSource="{Binding ConfigProfileViewModels}">
+												<ItemsControl.Style>
+													<Style TargetType="ItemsControl">
+														<Setter Property="Visibility" Value="Visible" />
 														<Style.Triggers>
-															<DataTrigger Binding="{Binding IsManuallyOrdered}" Value="False">
+															<DataTrigger Binding="{Binding HasAnyProfiles}" Value="False">
 																<Setter Property="Visibility" Value="Collapsed" />
 															</DataTrigger>
 														</Style.Triggers>
 													</Style>
-												</Grid.Style>
-												<Grid.RowDefinitions>
-													<RowDefinition Height="Auto" />
-													<RowDefinition Height="Auto" />
-												</Grid.RowDefinitions>
-												<TextBlock FontSize="10"><Hyperlink Command="{Binding MoveUp}" TextDecorations="None">🔼</Hyperlink></TextBlock>
-												<TextBlock Grid.Row="1" FontSize="10"><Hyperlink Command="{Binding MoveDown}" TextDecorations="None">🔽</Hyperlink></TextBlock>
-											</Grid>
-											<TextBlock Grid.Column="3" Margin="10" FontSize="16">
-												<Hyperlink Command="{Binding Disable}">
-													<TextBlock>
-														<TextBlock.Style>
-															<Style>
-																<Setter Property="TextBlock.Foreground" Value="Green" />
-																<Setter Property="TextBlock.Text" Value="Enabled" />
-																<Setter Property="FrameworkElement.ToolTip" Value="Toggle whether this browser appears in the picker" />
-																<Style.Triggers>
-																	<DataTrigger Binding="{Binding Model.Disabled}" Value="True">
-																		<Setter Property="TextBlock.Foreground" Value="OrangeRed" />
-																		<Setter Property="TextBlock.Text" Value="Disabled" />
-																	</DataTrigger>
-																</Style.Triggers>
-															</Style>
-														</TextBlock.Style>
-													</TextBlock>
-												</Hyperlink>
-											</TextBlock>
-											<TextBlock Grid.Column="4" Margin="10" FontSize="16">
-												<Hyperlink Command="{Binding Edit}">
-													<TextBlock Foreground="CadetBlue" Text="Edit" ToolTip="Edit browser definition" />
-												</Hyperlink>
-											</TextBlock>
-											<TextBlock Grid.Column="5" Margin="10" FontSize="16">
-												<Hyperlink Command="{Binding Duplicate}">
-													<TextBlock Foreground="LightGreen" Text="+" ToolTip="Duplicate browser: create a new browser using this browser as a starting point" />
-												</Hyperlink>
-											</TextBlock>
-											<TextBlock Grid.Column="6" Margin="10" FontSize="16">
-												<TextBlock.Style>
-													<Style TargetType="TextBlock">
-														<Style.Triggers>
-															<DataTrigger Binding="{Binding CanRemove}" Value="False">
-																<Setter Property="Visibility" Value="Hidden" />
-															</DataTrigger>
-														</Style.Triggers>
-													</Style>
-												</TextBlock.Style>
-												<Hyperlink Command="{Binding Remove}">
-													<TextBlock Foreground="Red" Text="X" ToolTip="Remove custom browser from list" />
-												</Hyperlink>
-											</TextBlock>
-										</Grid>
+												</ItemsControl.Style>
+												<ItemsControl.ItemTemplate>
+													<DataTemplate DataType="viewModels:BrowserProfileViewModel">
+														<Grid Margin="0,2">
+															<Grid.ColumnDefinitions>
+																<ColumnDefinition Width="*" />
+																<ColumnDefinition Width="Auto" />
+															</Grid.ColumnDefinitions>
+															<TextBlock VerticalAlignment="Center" Text="{Binding Model.Name}">
+																<TextBlock.Style>
+																	<Style TargetType="TextBlock">
+																		<Setter Property="Opacity" Value="1" />
+																		<Style.Triggers>
+																			<DataTrigger Binding="{Binding Hidden}" Value="True">
+																				<Setter Property="Opacity" Value="0.5" />
+																			</DataTrigger>
+																		</Style.Triggers>
+																	</Style>
+																</TextBlock.Style>
+															</TextBlock>
+															<TextBlock Grid.Column="1" Margin="10,0" VerticalAlignment="Center" FontSize="14">
+																<Hyperlink Command="{Binding ToggleVisibility}" TextDecorations="None">
+																	<TextBlock ToolTip="Toggle whether this profile appears in the picker">
+																		<TextBlock.Style>
+																			<Style TargetType="TextBlock">
+																				<Setter Property="Foreground" Value="Green" />
+																				<Setter Property="Text" Value="Visible" />
+																				<Style.Triggers>
+																					<DataTrigger Binding="{Binding Hidden}" Value="True">
+																						<Setter Property="Foreground" Value="OrangeRed" />
+																						<Setter Property="Text" Value="Hidden" />
+																					</DataTrigger>
+																				</Style.Triggers>
+																			</Style>
+																		</TextBlock.Style>
+																	</TextBlock>
+																</Hyperlink>
+															</TextBlock>
+														</Grid>
+													</DataTemplate>
+												</ItemsControl.ItemTemplate>
+											</ItemsControl>
+										</StackPanel>
 									</DataTemplate>
 								</ItemsControl.ItemTemplate>
 							</ItemsControl>
@@ -410,6 +464,9 @@
 							<TextBlock Margin="0,16,0,6" FontWeight="Bold" Text="Profile display" />
 							<RadioButton Margin="0,2" Content="Group profiles under browser" GroupName="ProfileDisplay" IsChecked="{Binding UseGroupedProfiles}" />
 							<RadioButton Margin="0,2,0,6" Content="Show profiles as separate entries" GroupName="ProfileDisplay" IsChecked="{Binding UseFlatProfiles}" />
+							<CheckBox Margin="0,2,0,6" IsChecked="{Binding Settings.PersistProfileExpansion}" IsEnabled="{Binding UseGroupedProfiles}" ToolTip="When checked, a browser's expanded/collapsed profile list is remembered. When unchecked, profile groups always start collapsed.">
+								<TextBlock Text="Remember expanded profile groups between launches" TextWrapping="Wrap" />
+							</CheckBox>
 						</StackPanel>
 
 						<!--  Right: Selection & defaults  -->

--- a/src/BrowserPicker.Windows/AppSettings.cs
+++ b/src/BrowserPicker.Windows/AppSettings.cs
@@ -177,6 +177,9 @@ public sealed class AppSettings : IApplicationSettings
 	/// <inheritdoc />
 	public ProfileDisplayMode ProfileDisplayMode { get; set; }
 
+	/// <inheritdoc />
+	public bool PersistProfileExpansion { get; set; } = true;
+
 	private List<DefaultSetting> GetDefaults()
 	{
 		if (Reg == null)

--- a/src/BrowserPicker.Windows/JsonAppSettings.cs
+++ b/src/BrowserPicker.Windows/JsonAppSettings.cs
@@ -55,6 +55,7 @@ public sealed class JsonAppSettings : ModelBase, IBrowserPickerConfiguration
 	private double font_size = 14;
 	private ThemeMode theme_mode = ThemeMode.System;
 	private ProfileDisplayMode profile_display_mode;
+	private bool persist_profile_expansion = true;
 
 	private static readonly JsonSerializerOptions JsonOptions = new()
 	{
@@ -433,6 +434,16 @@ public sealed class JsonAppSettings : ModelBase, IBrowserPickerConfiguration
 		}
 	}
 
+	public bool PersistProfileExpansion
+	{
+		get => persist_profile_expansion;
+		set
+		{
+			if (SetProperty(ref persist_profile_expansion, value))
+				SaveToFile();
+		}
+	}
+
 	public List<BrowserModel> BrowserList { get; }
 
 	public List<DefaultSetting> Defaults { get; }
@@ -736,6 +747,7 @@ public sealed class JsonAppSettings : ModelBase, IBrowserPickerConfiguration
 		font_size = s.FontSize > 0 ? s.FontSize : 14;
 		theme_mode = s.ThemeMode;
 		profile_display_mode = s.ProfileDisplayMode;
+		persist_profile_expansion = s.PersistProfileExpansion;
 		OnPropertyChanged(nameof(SortBy));
 		OnPropertyChanged(nameof(UseAutomaticOrdering));
 		OnPropertyChanged(nameof(UseManualOrdering));

--- a/tests/BrowserPicker.Common.Tests/BrowserProfileSerializationTests.cs
+++ b/tests/BrowserPicker.Common.Tests/BrowserProfileSerializationTests.cs
@@ -1,0 +1,57 @@
+using System.Text.Json;
+using AwesomeAssertions;
+
+namespace BrowserPicker.Common.Tests;
+
+/// <summary>
+/// Regression tests for issue #304: browser profiles must survive a JSON round-trip so the picker
+/// shows them on every launch (notably in flat / "separate entries" display mode).
+/// </summary>
+public class BrowserProfileSerializationTests
+{
+	[Fact]
+	public void BrowserModelProfilesSurviveJsonRoundTrip()
+	{
+		var original = new BrowserModel("Firefox", null, "firefox.exe") { ContainersEnabled = true };
+		original.Profiles.Add(new BrowserProfile("container:Work", "Work", null, "ext+container:name=Work&url={url}"));
+		original.Profiles.Add(new BrowserProfile("container:Personal", "Personal", null));
+
+		var json = JsonSerializer.Serialize(original);
+		var restored = JsonSerializer.Deserialize<BrowserModel>(json);
+
+		restored.Should().NotBeNull();
+		restored!.Profiles.Should().HaveCount(2);
+		restored.Profiles[0].Id.Should().Be("container:Work");
+		restored.Profiles[0].Name.Should().Be("Work");
+		restored.Profiles[0].UrlTemplate.Should().Be("ext+container:name=Work&url={url}");
+		restored.Profiles[1].Id.Should().Be("container:Personal");
+	}
+
+	[Fact]
+	public void HiddenProfileFlagSurvivesJsonRoundTrip()
+	{
+		var original = new BrowserModel("Chrome", null, "chrome.exe");
+		original.Profiles.Add(new BrowserProfile("Default", "Personal", "--profile-directory=Default"));
+		original.Profiles.Add(
+			new BrowserProfile("Profile 1", "Junk", "--profile-directory=Profile 1") { Disabled = true }
+		);
+
+		var json = JsonSerializer.Serialize(original);
+		var restored = JsonSerializer.Deserialize<BrowserModel>(json);
+
+		restored!.Profiles.Should().HaveCount(2);
+		restored.Profiles[0].Disabled.Should().BeFalse();
+		restored.Profiles[1].Disabled.Should().BeTrue();
+	}
+
+	[Fact]
+	public void ProfilesExpandedStateSurvivesJsonRoundTrip()
+	{
+		var original = new BrowserModel("Firefox", null, "firefox.exe") { ProfilesExpanded = true };
+
+		var json = JsonSerializer.Serialize(original);
+		var restored = JsonSerializer.Deserialize<BrowserModel>(json);
+
+		restored!.ProfilesExpanded.Should().BeTrue();
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the three browser-profile problems reported in #304:

1. **Flat profile display ("Show profiles as separate entries") only worked once.** `BrowserModel.Profiles` was a get-only `List<>`, which `System.Text.Json` silently does not populate, so profiles never reloaded from `settings.json`; they only existed in memory after async discovery. In flat mode the entry list is a one-time snapshot built before discovery completes, so on a fresh launch it showed nothing.
   - `Profiles` (and `BrowserProfile.Id`) are now marked `[JsonInclude]` so they round-trip.
   - The picker rebuilds its entries after discovery (`Initialize` → `RefreshDiscoveredProfiles`) so newly discovered profiles also appear in flat mode.

2. **No way to hide unwanted profiles.** Added per-profile show/hide controls under each browser in the **Browsers** configuration tab (`BrowserProfile.Disabled` is now a settable, persisted flag; the picker filters hidden profiles out).

3. **Profile expander always reset to collapsed.** A browser's expanded/collapsed profile group is now persisted (`BrowserModel.ProfilesExpanded`), with a new **"Remember expanded profile groups between launches"** setting (`PersistProfileExpansion`, default on) to control it. When off, groups always start collapsed.

The settings JSON schema was regenerated for the new `PersistProfileExpansion` property.

## Test plan

- [x] `dotnet build` of all C# projects succeeds (WiX installer projects require published output and are out of scope).
- [x] `dotnet test` — 33/33 pass, including new round-trip regression tests for profiles, the hidden flag, and expander state.
- [x] Manually verified in the running app: profiles show on every launch in flat mode, profiles can be hidden/shown, and expansion persistence honors the new setting.

Fixes #304
