### PR TITLE
Fix IL3000 error in portable single-file build

### DIFF
--- a/src/BrowserPicker.Windows/UserDefaultBrowserRegistration.cs
+++ b/src/BrowserPicker.Windows/UserDefaultBrowserRegistration.cs
@@ -3,7 +3,6 @@ using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using System.Reflection;
 using Microsoft.Win32;
 
 namespace BrowserPicker.Windows;
@@ -262,10 +261,7 @@ public static class UserDefaultBrowserRegistration
 		[NotNullWhen(false)] out string? error
 	)
 	{
-		executablePath =
-			Environment.ProcessPath
-			?? Assembly.GetEntryAssembly()?.Location
-			?? Process.GetCurrentProcess().MainModule?.FileName;
+		executablePath = Environment.ProcessPath ?? Process.GetCurrentProcess().MainModule?.FileName;
 
 		if (string.IsNullOrWhiteSpace(executablePath))
 		{


### PR DESCRIPTION
## Summary

The portable (single-file) publish broke in both CI and the release pipeline with:

```
error IL3000: 'System.Reflection.Assembly.Location.get' always returns an empty
string for assemblies embedded in a single-file app.
src/BrowserPicker.Windows/UserDefaultBrowserRegistration.cs(267,35)
```

This was introduced in #281 (`UserDefaultBrowserRegistration`), which used `Assembly.GetEntryAssembly()?.Location` as a fallback when resolving the executable path. The single-file analyzer treats this as an error because `Assembly.Location` is always empty for assemblies embedded in a single-file app.

## What changed

- Removed the `Assembly.GetEntryAssembly()?.Location` fallback in `TryGetExecutablePath`. `Environment.ProcessPath` already resolves the executable path reliably for single-file apps, with `Process.GetCurrentProcess().MainModule?.FileName` as the remaining fallback.
- Removed the now-unused `using System.Reflection;`.

## Verification

- `dotnet publish src/BrowserPicker.UI/BrowserPicker.UI.csproj -c Release -r win-x64 -p:PublishSingleFile=true -p:Version=1.0.0 -p:Platform=x64` — builds clean (IL3000 gone), CSharpier-formatted.
